### PR TITLE
ci: fix push auth and artifact naming

### DIFF
--- a/.github/workflows/work.yml
+++ b/.github/workflows/work.yml
@@ -39,5 +39,5 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
-          name: work-${{ matrix.repo }}
+          name: work-${{ strategy.job-index }}
           path: o/

--- a/work.mk
+++ b/work.mk
@@ -114,6 +114,7 @@ push_done := $(o)/push/done
 $(push_done): $(do_done)
 	@echo "==> push"
 	@mkdir -p $(@D)
+	@git -C $(repo_dir) remote set-url origin https://x-access-token:$(GH_TOKEN)@github.com/$(REPO).git
 	@git -C $(repo_dir) push --force-with-lease -u origin HEAD
 	@touch $@
 


### PR DESCRIPTION
- set remote URL with GH_TOKEN for push to target repo
- use job index for artifact name to avoid slash in name