### PR TITLE
reduce workflow timeout to 15 minutes

### DIFF
--- a/.github/workflows/work.yml
+++ b/.github/workflows/work.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   work:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
     concurrency:
       group: work-${{ matrix.repo }}
       cancel-in-progress: false


### PR DESCRIPTION
60 minutes is excessive. 15 minutes is enough for the full work loop.