### PR TITLE
add ci: type checks and format checks using cosmic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Run type checks and format checks
+        run: make -j ci

--- a/skills/act/tools/comment-issue.tl
+++ b/skills/act/tools/comment-issue.tl
@@ -7,52 +7,52 @@ local cio = require("cosmic.io")
 local fs = require("cosmic.fs")
 local unix = require("cosmo.unix")
 
-local function run(argv: {string}): boolean, string, number
-   local h, err = child.spawn(argv, {
-      env = unix.environ() as {string},
-      stderr = 1,
-   })
-   if not h then
-      return false, err or "spawn failed", -1
-   end
-   return h:read()
+local function run(argv: {string}): boolean | string, string, number
+  local h, err = child.spawn(argv, {
+    env = unix.environ() as {string},
+    stderr = 1,
+  })
+  if not h then
+    return false, err or "spawn failed", -1
+  end
+  return h:read()
 end
 
 return {
-   name = "comment_issue",
-   description = "Post a comment on a GitHub issue.",
-   input_schema = {
-      type = "object",
-      properties = {
-         issue_url = {type = "string", description = "Full GitHub issue URL"},
-         body = {type = "string", description = "Comment body (markdown)"},
-      },
-      required = {"issue_url", "body"},
-   },
-   execute = function(input: {string:any}): string
-      local url = input.issue_url as string
-      local body = input.body as string
+  name = "comment_issue",
+  description = "Post a comment on a GitHub issue.",
+  input_schema = {
+    type = "object",
+    properties = {
+      issue_url = {type = "string", description = "Full GitHub issue URL"},
+      body = {type = "string", description = "Comment body (markdown)"},
+    },
+    required = {"issue_url", "body"},
+  },
+  execute = function(input: {string: any}): string
+    local url = input.issue_url as string
+    local body = input.body as string
 
-      if not url or url == "" then
-         return "error: issue_url required"
-      end
-      if not body or body == "" then
-         return "error: body required"
-      end
+    if not url or url == "" then
+      return "error: issue_url required"
+    end
+    if not body or body == "" then
+      return "error: body required"
+    end
 
-      local fd, tmp = fs.mkstemp("/tmp/comment-XXXXXX")
-      if not fd then
-         return "error: could not create temp file"
-      end
-      unix.close(fd)
-      cio.barf(tmp, body)
+    local fd, tmp = fs.mkstemp("/tmp/comment-XXXXXX")
+    if not fd then
+      return "error: could not create temp file"
+    end
+    unix.close(fd)
+    cio.barf(tmp, body)
 
-      local ok, out, code = run({"gh", "issue", "comment", url, "--body-file", tmp})
-      fs.unlink(tmp)
+    local ok, out, code = run({"gh", "issue", "comment", url, "--body-file", tmp})
+    fs.unlink(tmp)
 
-      if not ok then
-         return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
-      end
-      return "ok"
-   end,
+    if not ok then
+      return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
+    end
+    return "ok"
+  end,
 }

--- a/skills/act/tools/create-pr.tl
+++ b/skills/act/tools/create-pr.tl
@@ -7,62 +7,62 @@ local cio = require("cosmic.io")
 local fs = require("cosmic.fs")
 local unix = require("cosmo.unix")
 
-local function run(argv: {string}): boolean, string, number
-   local h, err = child.spawn(argv, {
-      env = unix.environ() as {string},
-      stderr = 1,
-   })
-   if not h then
-      return false, err or "spawn failed", -1
-   end
-   return h:read()
+local function run(argv: {string}): boolean | string, string, number
+  local h, err = child.spawn(argv, {
+    env = unix.environ() as {string},
+    stderr = 1,
+  })
+  if not h then
+    return false, err or "spawn failed", -1
+  end
+  return h:read()
 end
 
 return {
-   name = "create_pr",
-   description = "Create a pull request on a GitHub repository. Returns the PR URL on success.",
-   input_schema = {
-      type = "object",
-      properties = {
-         repo = {type = "string", description = "GitHub repository (owner/repo)"},
-         branch = {type = "string", description = "Head branch name"},
-         title = {type = "string", description = "PR title"},
-         body = {type = "string", description = "PR body (markdown)"},
-      },
-      required = {"repo", "branch", "title", "body"},
-   },
-   execute = function(input: {string:any}): string
-      local repo = input.repo as string
-      local branch = input.branch as string
-      local title = input.title as string
-      local body = input.body as string
+  name = "create_pr",
+  description = "Create a pull request on a GitHub repository. Returns the PR URL on success.",
+  input_schema = {
+    type = "object",
+    properties = {
+      repo = {type = "string", description = "GitHub repository (owner/repo)"},
+      branch = {type = "string", description = "Head branch name"},
+      title = {type = "string", description = "PR title"},
+      body = {type = "string", description = "PR body (markdown)"},
+    },
+    required = {"repo", "branch", "title", "body"},
+  },
+  execute = function(input: {string: any}): string
+    local repo = input.repo as string
+    local branch = input.branch as string
+    local title = input.title as string
+    local body = input.body as string
 
-      if not repo or repo == "" then return "error: repo required" end
-      if not branch or branch == "" then return "error: branch required" end
-      if not title or title == "" then return "error: title required" end
+    if not repo or repo == "" then return "error: repo required" end
+    if not branch or branch == "" then return "error: branch required" end
+    if not title or title == "" then return "error: title required" end
 
-      local fd, tmp = fs.mkstemp("/tmp/pr-body-XXXXXX")
-      if not fd then
-         return "error: could not create temp file"
+    local fd, tmp = fs.mkstemp("/tmp/pr-body-XXXXXX")
+    if not fd then
+      return "error: could not create temp file"
+    end
+    unix.close(fd)
+    cio.barf(tmp, body or "")
+
+    local ok, out, code = run({
+      "gh", "pr", "create",
+      "--repo", repo,
+      "--head", branch,
+      "--title", title,
+      "--body-file", tmp,
+    })
+    fs.unlink(tmp)
+
+    if not ok then
+      if out and out:find("already exists") then
+        return "ok: pr already exists"
       end
-      unix.close(fd)
-      cio.barf(tmp, body or "")
-
-      local ok, out, code = run({
-         "gh", "pr", "create",
-         "--repo", repo,
-         "--head", branch,
-         "--title", title,
-         "--body-file", tmp,
-      })
-      fs.unlink(tmp)
-
-      if not ok then
-         if out and out:find("already exists") then
-            return "ok: pr already exists"
-         end
-         return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
-      end
-      return "ok: " .. (out or ""):gsub("%s+$", "")
-   end,
+      return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
+    end
+    return "ok: " .. (out or ""):gsub("%s+$", "")
+  end,
 }

--- a/skills/act/tools/set-issue-labels.tl
+++ b/skills/act/tools/set-issue-labels.tl
@@ -5,57 +5,57 @@
 local child = require("cosmic.child")
 local unix = require("cosmo.unix")
 
-local function run(argv: {string}): boolean, string, number
-   local h, err = child.spawn(argv, {
-      env = unix.environ() as {string},
-      stderr = 1,
-   })
-   if not h then
-      return false, err or "spawn failed", -1
-   end
-   return h:read()
+local function run(argv: {string}): boolean | string, string, number
+  local h, err = child.spawn(argv, {
+    env = unix.environ() as {string},
+    stderr = 1,
+  })
+  if not h then
+    return false, err or "spawn failed", -1
+  end
+  return h:read()
 end
 
 return {
-   name = "set_issue_labels",
-   description = "Add and/or remove labels on a GitHub issue. Pass the issue URL and lists of labels to add/remove.",
-   input_schema = {
-      type = "object",
-      properties = {
-         issue_url = {type = "string", description = "Full GitHub issue URL"},
-         add = {type = "array", items = {type = "string"}, description = "Labels to add"},
-         remove = {type = "array", items = {type = "string"}, description = "Labels to remove"},
-      },
-      required = {"issue_url"},
-   },
-   execute = function(input: {string:any}): string
-      local url = input.issue_url as string
-      if not url or url == "" then
-         return "error: issue_url required"
-      end
+  name = "set_issue_labels",
+  description = "Add and/or remove labels on a GitHub issue. Pass the issue URL and lists of labels to add/remove.",
+  input_schema = {
+    type = "object",
+    properties = {
+      issue_url = {type = "string", description = "Full GitHub issue URL"},
+      add = {type = "array", items = {type = "string"}, description = "Labels to add"},
+      remove = {type = "array", items = {type = "string"}, description = "Labels to remove"},
+    },
+    required = {"issue_url"},
+  },
+  execute = function(input: {string: any}): string
+    local url = input.issue_url as string
+    if not url or url == "" then
+      return "error: issue_url required"
+    end
 
-      local argv: {string} = {"gh", "issue", "edit", url}
+    local argv: {string} = {"gh", "issue", "edit", url}
 
-      local add = input.add as {string}
-      if add then
-         for _, label in ipairs(add) do
-            table.insert(argv, "--add-label")
-            table.insert(argv, label)
-         end
+    local add = input.add as {string}
+    if add then
+      for _, label in ipairs(add) do
+        table.insert(argv, "--add-label")
+        table.insert(argv, label)
       end
+    end
 
-      local remove = input.remove as {string}
-      if remove then
-         for _, label in ipairs(remove) do
-            table.insert(argv, "--remove-label")
-            table.insert(argv, label)
-         end
+    local remove = input.remove as {string}
+    if remove then
+      for _, label in ipairs(remove) do
+        table.insert(argv, "--remove-label")
+        table.insert(argv, label)
       end
+    end
 
-      local ok, out, code = run(argv)
-      if not ok then
-         return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
-      end
-      return "ok"
-   end,
+    local ok, out, code = run(argv)
+    if not ok then
+      return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
+    end
+    return "ok"
+  end,
 }

--- a/skills/pick/tools/count-open-prs.tl
+++ b/skills/pick/tools/count-open-prs.tl
@@ -6,43 +6,43 @@ local child = require("cosmic.child")
 local unix = require("cosmo.unix")
 local json = require("cosmic.json")
 
-local function run(argv: {string}): boolean, string, number
-   local h, err = child.spawn(argv, {
-      env = unix.environ() as {string},
-      stderr = 1,
-   })
-   if not h then
-      return false, err or "spawn failed", -1
-   end
-   return h:read()
+local function run(argv: {string}): boolean | string, string, number
+  local h, err = child.spawn(argv, {
+    env = unix.environ() as {string},
+    stderr = 1,
+  })
+  if not h then
+    return false, err or "spawn failed", -1
+  end
+  return h:read()
 end
 
 return {
-   name = "count_open_prs",
-   description = "Count the number of open pull requests on a GitHub repository. Returns a number.",
-   input_schema = {
-      type = "object",
-      properties = {
-         repo = {type = "string", description = "GitHub repository (owner/repo)"},
-      },
-      required = {"repo"},
-   },
-   execute = function(input: {string:any}): string
-      local repo = input.repo as string
-      if not repo or repo == "" then
-         return "error: repo argument required"
-      end
+  name = "count_open_prs",
+  description = "Count the number of open pull requests on a GitHub repository. Returns a number.",
+  input_schema = {
+    type = "object",
+    properties = {
+      repo = {type = "string", description = "GitHub repository (owner/repo)"},
+    },
+    required = {"repo"},
+  },
+  execute = function(input: {string: any}): string
+    local repo = input.repo as string
+    if not repo or repo == "" then
+      return "error: repo argument required"
+    end
 
-      local ok, out, code = run({"gh", "pr", "list", "--repo", repo, "--state", "open", "--json", "number"})
-      if not ok then
-         return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
-      end
+    local ok, out, code = run({"gh", "pr", "list", "--repo", repo, "--state", "open", "--json", "number"})
+    if not ok then
+      return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
+    end
 
-      local prs = json.decode(out or "[]") as {any}
-      if not prs then
-         return "error: failed to parse PR list"
-      end
+    local prs = json.decode(out or "[]") as {any}
+    if not prs then
+      return "error: failed to parse PR list"
+    end
 
-      return tostring(#prs)
-   end,
+    return tostring(#prs)
+  end,
 }

--- a/skills/pick/tools/ensure-labels.tl
+++ b/skills/pick/tools/ensure-labels.tl
@@ -5,45 +5,45 @@
 local child = require("cosmic.child")
 local unix = require("cosmo.unix")
 
-local function run(argv: {string}): boolean, string, number
-   local h, err = child.spawn(argv, {
-      env = unix.environ() as {string},
-      stderr = 1,
-   })
-   if not h then
-      return false, err or "spawn failed", -1
-   end
-   return h:read()
+local function run(argv: {string}): boolean | string, string, number
+  local h, err = child.spawn(argv, {
+    env = unix.environ() as {string},
+    stderr = 1,
+  })
+  if not h then
+    return false, err or "spawn failed", -1
+  end
+  return h:read()
 end
 
 return {
-   name = "ensure_labels",
-   description = "Ensure required work labels (todo, doing, done, failed) exist on a GitHub repository.",
-   input_schema = {
-      type = "object",
-      properties = {
-         repo = {type = "string", description = "GitHub repository (owner/repo)"},
-      },
-      required = {"repo"},
-   },
-   execute = function(input: {string:any}): string
-      local repo = input.repo as string
-      if not repo or repo == "" then
-         return "error: repo argument required"
-      end
+  name = "ensure_labels",
+  description = "Ensure required work labels (todo, doing, done, failed) exist on a GitHub repository.",
+  input_schema = {
+    type = "object",
+    properties = {
+      repo = {type = "string", description = "GitHub repository (owner/repo)"},
+    },
+    required = {"repo"},
+  },
+  execute = function(input: {string: any}): string
+    local repo = input.repo as string
+    if not repo or repo == "" then
+      return "error: repo argument required"
+    end
 
-      local labels = {"todo", "doing", "done", "failed"}
-      local errors: {string} = {}
-      for _, label in ipairs(labels) do
-         local ok, out = run({"gh", "label", "create", label, "--repo", repo, "--force"})
-         if not ok then
-            table.insert(errors, label .. ": " .. (out or ""))
-         end
+    local labels = {"todo", "doing", "done", "failed"}
+    local errors: {string} = {}
+    for _, label in ipairs(labels) do
+      local ok, out = run({"gh", "label", "create", label, "--repo", repo, "--force"})
+      if not ok then
+        table.insert(errors, label .. ": " .. (out or ""))
       end
+    end
 
-      if #errors > 0 then
-         return "errors: " .. table.concat(errors, "; ")
-      end
-      return "ok"
-   end,
+    if #errors > 0 then
+      return "errors: " .. table.concat(errors, "; ")
+    end
+    return "ok"
+  end,
 }

--- a/skills/pick/tools/list-issues.tl
+++ b/skills/pick/tools/list-issues.tl
@@ -6,50 +6,50 @@ local child = require("cosmic.child")
 local unix = require("cosmo.unix")
 local json = require("cosmic.json")
 
-local function run(argv: {string}): boolean, string, number
-   local h, err = child.spawn(argv, {
-      env = unix.environ() as {string},
-      stderr = 1,
-   })
-   if not h then
-      return false, err or "spawn failed", -1
-   end
-   return h:read()
+local function run(argv: {string}): boolean | string, string, number
+  local h, err = child.spawn(argv, {
+    env = unix.environ() as {string},
+    stderr = 1,
+  })
+  if not h then
+    return false, err or "spawn failed", -1
+  end
+  return h:read()
 end
 
 return {
-   name = "list_issues",
-   description = "Fetch open issues labeled 'todo' from a GitHub repository. Pass owner/repo as the repo argument.",
-   input_schema = {
-      type = "object",
-      properties = {
-         repo = {type = "string", description = "GitHub repository (owner/repo)"},
-      },
-      required = {"repo"},
-   },
-   execute = function(input: {string:any}): string
-      local repo = input.repo as string
-      if not repo or repo == "" then
-         return "error: repo argument required"
-      end
+  name = "list_issues",
+  description = "Fetch open issues labeled 'todo' from a GitHub repository. Pass owner/repo as the repo argument.",
+  input_schema = {
+    type = "object",
+    properties = {
+      repo = {type = "string", description = "GitHub repository (owner/repo)"},
+    },
+    required = {"repo"},
+  },
+  execute = function(input: {string: any}): string
+    local repo = input.repo as string
+    if not repo or repo == "" then
+      return "error: repo argument required"
+    end
 
-      local ok, out, code = run({
-         "gh", "issue", "list",
-         "--repo", repo,
-         "--label", "todo",
-         "--state", "open",
-         "--json", "number,title,body,url,labels,createdAt",
-         "--limit", "100",
-      })
-      if not ok then
-         return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
-      end
+    local ok, out, code = run({
+      "gh", "issue", "list",
+      "--repo", repo,
+      "--label", "todo",
+      "--state", "open",
+      "--json", "number,title,body,url,labels,createdAt",
+      "--limit", "100",
+    })
+    if not ok then
+      return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
+    end
 
-      local issues = json.decode(out or "[]")
-      if not issues then
-         return "error: failed to parse issues json"
-      end
+    local issues = json.decode(out or "[]")
+    if not issues then
+      return "error: failed to parse issues json"
+    end
 
-      return json.encode(issues)
-   end,
+    return (json.encode(issues))
+  end,
 }

--- a/skills/pick/tools/set-issue-labels.tl
+++ b/skills/pick/tools/set-issue-labels.tl
@@ -5,57 +5,57 @@
 local child = require("cosmic.child")
 local unix = require("cosmo.unix")
 
-local function run(argv: {string}): boolean, string, number
-   local h, err = child.spawn(argv, {
-      env = unix.environ() as {string},
-      stderr = 1,
-   })
-   if not h then
-      return false, err or "spawn failed", -1
-   end
-   return h:read()
+local function run(argv: {string}): boolean | string, string, number
+  local h, err = child.spawn(argv, {
+    env = unix.environ() as {string},
+    stderr = 1,
+  })
+  if not h then
+    return false, err or "spawn failed", -1
+  end
+  return h:read()
 end
 
 return {
-   name = "set_issue_labels",
-   description = "Add and/or remove labels on a GitHub issue. Pass the issue URL and lists of labels to add/remove.",
-   input_schema = {
-      type = "object",
-      properties = {
-         issue_url = {type = "string", description = "Full GitHub issue URL"},
-         add = {type = "array", items = {type = "string"}, description = "Labels to add"},
-         remove = {type = "array", items = {type = "string"}, description = "Labels to remove"},
-      },
-      required = {"issue_url"},
-   },
-   execute = function(input: {string:any}): string
-      local url = input.issue_url as string
-      if not url or url == "" then
-         return "error: issue_url required"
-      end
+  name = "set_issue_labels",
+  description = "Add and/or remove labels on a GitHub issue. Pass the issue URL and lists of labels to add/remove.",
+  input_schema = {
+    type = "object",
+    properties = {
+      issue_url = {type = "string", description = "Full GitHub issue URL"},
+      add = {type = "array", items = {type = "string"}, description = "Labels to add"},
+      remove = {type = "array", items = {type = "string"}, description = "Labels to remove"},
+    },
+    required = {"issue_url"},
+  },
+  execute = function(input: {string: any}): string
+    local url = input.issue_url as string
+    if not url or url == "" then
+      return "error: issue_url required"
+    end
 
-      local argv: {string} = {"gh", "issue", "edit", url}
+    local argv: {string} = {"gh", "issue", "edit", url}
 
-      local add = input.add as {string}
-      if add then
-         for _, label in ipairs(add) do
-            table.insert(argv, "--add-label")
-            table.insert(argv, label)
-         end
+    local add = input.add as {string}
+    if add then
+      for _, label in ipairs(add) do
+        table.insert(argv, "--add-label")
+        table.insert(argv, label)
       end
+    end
 
-      local remove = input.remove as {string}
-      if remove then
-         for _, label in ipairs(remove) do
-            table.insert(argv, "--remove-label")
-            table.insert(argv, label)
-         end
+    local remove = input.remove as {string}
+    if remove then
+      for _, label in ipairs(remove) do
+        table.insert(argv, "--remove-label")
+        table.insert(argv, label)
       end
+    end
 
-      local ok, out, code = run(argv)
-      if not ok then
-         return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
-      end
-      return "ok"
-   end,
+    local ok, out, code = run(argv)
+    if not ok then
+      return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
+    end
+    return "ok"
+  end,
 }


### PR DESCRIPTION
## Summary

Add CI pipeline with type checking and format checking for all `.tl` files using cosmic.

### Changes

**Makefile targets:**
- `make check-types` — runs `cosmic --check-types` (strict mode) on all `.tl` files
- `make check-format` — diffs each `.tl` file against `cosmic --format` output
- `make ci` — runs both checks; incremental (only re-checks changed files)

**GitHub Actions:** `.github/workflows/test.yml` runs `make -j ci` on push/PR to main.

**Code fixes:**
- Fixed `run()` return type to `boolean | string, string, number` matching `child.Handle:read()` (all 7 tool files)
- Wrapped `json.encode()` in parens to truncate excess return value
- Reformatted all `.tl` files to cosmic 2-space indent style