### PR TITLE
add scripts/generate-app-token

### DIFF
--- a/scripts/generate-app-token.tl
+++ b/scripts/generate-app-token.tl
@@ -72,6 +72,7 @@ local function build_jwt(app_id: string, key_path: string): string
   return signing_input .. "." .. base64url(signature)
 end
 
+-- TODO: switch to cosmic.fetch after cosmic/issues/271 adds POST support
 local function fetch_token(jwt: string, installation_id: string): string
   local url = "https://api.github.com/app/installations/" .. installation_id .. "/access_tokens"
   local status, _, body = cosmo.Fetch(url, {


### PR DESCRIPTION
teal script to generate github app installation access tokens.
reads a PEM private key, builds a RS256 JWT via openssl, exchanges
it for an installation token via the github api.

accepts --app-id, --installation-id, --key flags or equivalent
env vars (APP_ID, INSTALLATION_ID, PRIVATE_KEY_PATH).
