### PR TITLE
list_issues: return issues labeled todo or filed by collaborators

### DIFF
--- a/skills/pick/SKILL.md
+++ b/skills/pick/SKILL.md
@@ -15,8 +15,8 @@ You are selecting the next issue to work on from a GitHub repository.
 
 1. Run `ensure_labels` with `repo` set to REPO.
 2. Run `count_open_prs` with `repo` set to REPO. If more than 4, write `o/pick/issue.json` with `{"error": "pr limit"}` and stop.
-3. Run `list_issues` with `repo` set to REPO to get open todo issues.
-4. Analyze the issues. For each, assess:
+3. Run `list_issues` with `repo` set to REPO to get open issues (returns issues labeled `todo` plus issues filed by repo collaborators).
+4. Analyze the issues. Prefer issues labeled `todo` — collaborator-filed issues without `todo` are lower priority candidates. For each, assess:
    - **priority**: p0 > p1 > p2 > unlabeled (check labels array)
    - **age**: older issues first (createdAt)
    - **clarity**: is the issue specific enough to plan and execute?

--- a/skills/pick/tools/list-issues.tl
+++ b/skills/pick/tools/list-issues.tl
@@ -1,5 +1,6 @@
--- skills/pick/tools/list-issues.tl: fetch open todo issues from a github repo
+-- skills/pick/tools/list-issues.tl: fetch open issues from a github repo
 --
+-- returns issues that are either labeled "todo" or filed by repo collaborators.
 -- module tool: returns a Tool record for ah to load via -t
 
 local child = require("cosmic.child")
@@ -17,9 +18,35 @@ local function run(argv: {string}): boolean | string, string, number
   return h:read()
 end
 
+local COLLABORATOR_ASSOCIATIONS: {string: boolean} = {
+  OWNER = true,
+  MEMBER = true,
+  COLLABORATOR = true,
+}
+
+local QUERY = [[
+query($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    issues(first: 100, after: $cursor, states: OPEN, orderBy: {field: CREATED_AT, direction: ASC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        title
+        body
+        url
+        authorAssociation
+        createdAt
+        author { login }
+        labels(first: 20) { nodes { name } }
+      }
+    }
+  }
+}
+]]
+
 return {
   name = "list_issues",
-  description = "Fetch open issues labeled 'todo' from a GitHub repository. Pass owner/repo as the repo argument.",
+  description = "Fetch open issues from a GitHub repository that are either labeled 'todo' or filed by repo collaborators (owner/member/collaborator). Pass owner/repo as the repo argument.",
   input_schema = {
     type = "object",
     properties = {
@@ -33,23 +60,91 @@ return {
       return "error: repo argument required"
     end
 
-    local ok, out, code = run({
-      "gh", "issue", "list",
-      "--repo", repo,
-      "--label", "todo",
-      "--state", "open",
-      "--json", "number,title,body,url,labels,createdAt",
-      "--limit", "100",
-    })
-    if not ok then
-      return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
+    local owner, name = repo:match("^([^/]+)/([^/]+)$")
+    if not owner or not name then
+      return "error: repo must be owner/name format"
     end
 
-    local issues = json.decode(out or "[]")
-    if not issues then
-      return "error: failed to parse issues json"
+    local all_issues: {any} = {}
+    local cursor: string = ""
+    local has_cursor = false
+
+    for _ = 1, 10 do -- max 10 pages (1000 issues)
+      local argv: {string} = {
+        "gh", "api", "graphql",
+        "-f", "query=" .. QUERY,
+        "-f", "owner=" .. owner,
+        "-f", "name=" .. name,
+      }
+      if has_cursor then
+        argv[#argv + 1] = "-f"
+        argv[#argv + 1] = "cursor=" .. cursor
+      end
+
+      local ok, out, code = run(argv)
+      if not ok then
+        return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
+      end
+
+      local resp = json.decode(out or "{}") as {string: any}
+      if not resp or not resp.data then
+        local errors = resp and resp.errors as {any}
+        if errors and #errors > 0 then
+          local first = errors[1] as {string: any}
+          return "error: graphql: " .. tostring(first.message or "unknown")
+        end
+        return "error: failed to parse graphql response"
+      end
+
+      local data = resp.data as {string: any}
+      local repository = data.repository as {string: any}
+      local issues_conn = repository.issues as {string: any}
+      local nodes = issues_conn.nodes as {any}
+
+      for _, node_any in ipairs(nodes) do
+        local node = node_any as {string: any}
+        local labels_conn = node.labels as {string: any}
+        local label_nodes = labels_conn.nodes as {any}
+
+        -- check if issue has todo label
+        local has_todo = false
+        local label_list: {any} = {}
+        for _, ln_any in ipairs(label_nodes) do
+          local ln = ln_any as {string: any}
+          local lname = ln.name as string
+          label_list[#label_list + 1] = {name = lname}
+          if lname == "todo" then
+            has_todo = true
+          end
+        end
+
+        -- check if author is a collaborator
+        local assoc = node.authorAssociation as string
+        local is_collaborator = COLLABORATOR_ASSOCIATIONS[assoc] or false
+
+        if has_todo or is_collaborator then
+          local author_obj = node.author as {string: any}
+          all_issues[#all_issues + 1] = {
+            number = node.number,
+            title = node.title,
+            body = node.body,
+            url = node.url,
+            createdAt = node.createdAt,
+            labels = label_list,
+            authorAssociation = assoc,
+            author = author_obj and author_obj.login or nil,
+          }
+        end
+      end
+
+      local page_info = issues_conn.pageInfo as {string: any}
+      if not (page_info.hasNextPage as boolean) then
+        break
+      end
+      cursor = page_info.endCursor as string
+      has_cursor = true
     end
 
-    return (json.encode(issues))
+    return (json.encode(all_issues))
   end,
 }

--- a/skills/pick/tools/test_list_issues.tl
+++ b/skills/pick/tools/test_list_issues.tl
@@ -32,4 +32,18 @@ local function test_empty_repo()
 end
 test_empty_repo()
 
+local function test_bad_repo_format()
+  local result = tool.execute({repo = "noslash"})
+  assert(result == "error: repo must be owner/name format", "should error on bad format: " .. result)
+  print("✓ list_issues rejects bad repo format")
+end
+test_bad_repo_format()
+
+local function test_bad_repo_format_extra_slash()
+  local result = tool.execute({repo = "a/b/c"})
+  assert(result == "error: repo must be owner/name format", "should error on extra slash: " .. result)
+  print("✓ list_issues rejects repo with extra slashes")
+end
+test_bad_repo_format_extra_slash()
+
 print("\nAll list_issues tests passed!")


### PR DESCRIPTION
switch from gh issue list to graphql API to access authorAssociation.
filter client-side: keep issues with todo label or authored by
OWNER/MEMBER/COLLABORATOR. supports pagination up to 1000 issues.

the pick skill now considers collaborator-filed issues as lower-priority
candidates behind todo-labeled issues.