### PR TITLE
reflect: per-run analysis, fix auth, artifact inspection

### DIFF
--- a/.github/workflows/reflect.yml
+++ b/.github/workflows/reflect.yml
@@ -24,6 +24,8 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Reflect
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ the workflows require two secrets:
 ```
 Makefile              build, test, ci targets; cosmic/ah dependency fetching
 work.mk               work loop targets (pick → clone → plan → do → push → check → act)
-reflect.mk            reflect loop targets (fetch → analyze → publish)
+reflect.mk            reflect loop targets (fetch → analyze → summarize → publish)
 skills/               agent skills and their tools
   pick/               select next issue from github
     SKILL.md          pick skill prompt
@@ -82,7 +82,7 @@ skills/               agent skills and their tools
     SKILL.md          act skill prompt
     tools/            tl tool modules (comment-issue, create-pr, set-issue-labels)
   reflect/            retrospective analysis of workflow runs
-    SKILL.md          reflect skill prompt (fetch, analyze, publish phases)
+    SKILL.md          reflect skill prompt (fetch, analyze-run, summarize phases)
     tools/            tl tool modules (get-workflow-runs)
 .github/workflows/
   test.yml            CI: runs `make -j ci` on push/PR

--- a/docs/reflect.md
+++ b/docs/reflect.md
@@ -3,7 +3,7 @@
 a daily retrospective analysis of workflow runs. `make reflect` drives the cycle:
 
 ```
-fetch → analyze → publish
+fetch → analyze (per-run) → summarize → publish
 ```
 
 runs daily via the `reflect.yml` workflow. outputs go to `o/reflect/`. all runs come from `whilp/working` (this repo).
@@ -12,7 +12,9 @@ runs daily via the `reflect.yml` workflow. outputs go to `o/reflect/`. all runs 
 
 **fetch** — downloads workflow run logs and artifacts for a date range using `get_workflow_runs` tool. writes manifest and run data to `o/reflect/fetch/`. has network access (needs `gh` CLI).
 
-**analyze** — sandboxed (no network, limited unveil). reads fetched data and produces `o/reflect/analyze/reflection.md`. analyzes success rates, failure patterns, work loop outcomes, and agent friction.
+**analyze** — one sandboxed agent per workflow run. each reads that run's log and artifacts, produces a concise analysis in `o/reflect/analyze/<run-id>.md`. keeps context small by isolating each run.
+
+**summarize** — one sandboxed agent reads all per-run analyses and produces `o/reflect/summarize/reflection.md`. synthesizes success rates, failure patterns, work loop outcomes, and recommendations.
 
 **publish** — plain make recipe (no agent). copies `reflection.md` to `note/YYYY-MM-DD/reflection.md`, commits, pushes a branch, and opens a PR.
 

--- a/reflect.mk
+++ b/reflect.mk
@@ -1,13 +1,14 @@
 # reflect.mk: reflection targets
 #
 # implements the reflect loop as make targets:
-#   fetch -> analyze -> publish
+#   fetch -> analyze (per-run) -> summarize -> publish
 #
 # fetch: download workflow run logs and artifacts for a date range.
-# analyze: sandboxed analysis producing reflection.md.
-# publish: place reflection.md in note/YYYY-MM-DD/ and open a PR.
+# analyze: one sandboxed agent per run, producing a short analysis.
+# summarize: one sandboxed agent reads all analyses, produces reflection.md.
+# publish: commit reflection.md to note/YYYY-MM-DD/ and open a PR.
 #
-# all runs come from whilp/working (this repo). no matrix needed.
+# all runs come from whilp/working (this repo).
 
 REFLECT_REPO := whilp/working
 
@@ -24,10 +25,11 @@ reflect_branch := reflect/$(DATE)
 # directories
 fetch_dir := $(o)/reflect/fetch
 analyze_dir := $(o)/reflect/analyze
+summarize_dir := $(o)/reflect/summarize
 
 # named targets
 fetch_done := $(fetch_dir)/fetch-done
-reflection := $(analyze_dir)/reflection.md
+reflection := $(summarize_dir)/reflection.md
 publish_done := $(o)/reflect/publish-done
 
 .DELETE_ON_ERROR:
@@ -50,37 +52,78 @@ $(fetch_done): $(ah) $(cosmic)
 .PHONY: fetch
 fetch: $(fetch_done)
 
-# --- analyze ---
+# --- analyze: one agent per run ---
+# after fetch, read manifest.json and launch a sandboxed agent for each run.
+# each produces analyze_dir/<run-id>.md.
 
-$(reflection): $(fetch_done) $(ah)
+analyze_done := $(analyze_dir)/done
+
+$(analyze_done): $(fetch_done) $(ah)
 	@mkdir -p $(analyze_dir)
-	@echo "==> reflect: analyze"
-	@timeout 180 $(ah) -n \
-		-m opus \
+	@echo "==> reflect: analyze runs"
+	@python3 -c "\
+	import json, subprocess, sys, os; \
+	manifest = json.load(open('$(fetch_dir)/manifest.json')); \
+	runs = [r for r in manifest if r.get('log_file')]; \
+	print(f'  {len(runs)} runs to analyze'); \
+	failed = 0; \
+	for r in runs: \
+	    rid = str(r['databaseId']); \
+	    out = '$(analyze_dir)/' + rid + '.md'; \
+	    run_dir = '$(fetch_dir)/' + rid; \
+	    meta = json.dumps(r); \
+	    stdin = f'PHASE=analyze-run RUN_DIR={run_dir} RUN_META={meta} OUTPUT_FILE={out}'; \
+	    print(f'  -> {rid}: {r.get(\"workflowName\",\"?\")} ({r.get(\"conclusion\",\"?\")})'); \
+	    ret = subprocess.run([ \
+	        '$(ah)', '-n', '-m', 'sonnet', \
+	        '--sandbox', \
+	        '--skill', 'reflect', \
+	        '--must-produce', out, \
+	        '--max-tokens', '30000', \
+	        '--db', '$(analyze_dir)/session-' + rid + '.db', \
+	        '--unveil', run_dir + ':r', \
+	        '--unveil', '$(analyze_dir):rwc', \
+	        '--unveil', '.:r', \
+	    ], input=stdin.encode(), timeout=120); \
+	    if ret.returncode != 0: \
+	        print(f'  !! {rid} failed (exit {ret.returncode})'); \
+	        failed += 1; \
+	print(f'  done: {len(runs) - failed}/{len(runs)} succeeded'); \
+	" || true
+	@touch $@
+
+.PHONY: analyze
+analyze: $(analyze_done)
+
+# --- summarize ---
+
+$(reflection): $(analyze_done) $(ah)
+	@mkdir -p $(summarize_dir)
+	@echo "==> reflect: summarize"
+	@timeout 120 $(ah) -n \
+		-m sonnet \
 		--sandbox \
 		--skill reflect \
 		--must-produce $(reflection) \
-		--max-tokens 100000 \
-		--db $(analyze_dir)/session.db \
-		--unveil $(fetch_dir):r \
-		--unveil $(analyze_dir):rwc \
+		--max-tokens 50000 \
+		--db $(summarize_dir)/session.db \
+		--unveil $(analyze_dir):r \
+		--unveil $(summarize_dir):rwc \
 		--unveil .:r \
-		<<< "PHASE=analyze FETCH_DIR=$(fetch_dir) OUTPUT_DIR=$(analyze_dir)"
+		<<< "PHASE=summarize ANALYSIS_DIR=$(analyze_dir) DATE=$(DATE) OUTPUT_FILE=$(reflection)"
 
-.PHONY: analyze
-analyze: $(reflection)
+.PHONY: summarize
+summarize: $(reflection)
 
 # --- publish ---
 
 $(publish_done): $(reflection)
 	@echo "==> reflect: publish"
-	@test -n "$(GH_TOKEN)" || { echo "error: GH_TOKEN not set"; exit 1; }
 	@git checkout -B $(reflect_branch)
 	@mkdir -p note/$(DATE)
 	@cp $(reflection) note/$(DATE)/reflection.md
 	@git add note/$(DATE)/reflection.md
 	@git commit -m "reflect: add $(DATE) reflection"
-	@git remote set-url origin https://x-access-token:$(GH_TOKEN)@github.com/$(REFLECT_REPO).git
 	@git push --force-with-lease -u origin $(reflect_branch)
 	@gh pr create \
 		--repo $(REFLECT_REPO) \

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -5,7 +5,7 @@ description: Analyze workflow runs and produce a daily reflection.
 
 # Reflect
 
-You are running one phase of the reflect pipeline. The phase is specified after `---` below as `PHASE=<fetch|analyze>`.
+You are running one phase of the reflect pipeline. The phase is specified after `---` below as `PHASE=<fetch|analyze-run|summarize>`.
 
 ---
 
@@ -39,39 +39,97 @@ Download workflow run logs and artifacts for a date range.
 
 ---
 
-## Phase: analyze
+## Phase: analyze-run
 
-Analyze workflow run data and produce a reflection document. You are sandboxed with no network access. All data is already in FETCH_DIR.
+Analyze a single workflow run. You are sandboxed with no network access.
 
 ### Environment
 
-- `FETCH_DIR` — directory containing fetched run data.
-- `OUTPUT_DIR` — directory to write reflection output.
+- `RUN_DIR` — directory containing this run's log and artifacts.
+- `RUN_META` — JSON string with run metadata (from manifest).
+- `OUTPUT_FILE` — path to write the analysis.
 
 ### Instructions
 
-1. Read `FETCH_DIR/manifest.json` to get the list of runs.
-2. For each run, read the log file and any artifacts.
-3. Analyze across all runs:
-   - **success rate**: how many runs passed vs failed vs cancelled?
-   - **failure patterns**: what are the common failure modes? group by error type.
-   - **duration trends**: are runs getting faster or slower?
-   - **flakiness**: are there runs that fail intermittently on the same workflow?
-   - **work loop outcomes**: for work workflow runs, what issues were attempted? what was the verdict distribution (pass/needs-fixes/fail)?
-   - **agent friction**: look at session artifacts for signs of confusion, retries, or wasted tokens.
-   - **improvements**: what concrete changes would improve reliability or efficiency?
-4. Write `OUTPUT_DIR/reflection.md` with your analysis.
+1. Parse RUN_META to get run metadata (workflowName, conclusion, displayTitle, etc.).
+2. Read `RUN_DIR/log.txt`. Focus on:
+   - error lines, failure messages, exit codes
+   - phase transitions (==> pick, ==> plan, etc.)
+   - timing (how long each phase took)
+   - key outcomes (issue picked, verdict, PR created)
+3. Check `RUN_DIR/artifacts/` for structured data:
+   - `*/pick/issue.json` — which issue was picked
+   - `*/pick/reasoning.md` — why it was picked
+   - `*/plan/plan.md` — what was planned
+   - `*/do/do.md` — what was done
+   - `*/check/actions.json` — verdict and actions
+   - `*/do/feedback.md` — if needs-fixes, what feedback
+   - `*/act.json` — final outcome
+   - `**/session*.db` — session databases (note their presence/size)
+4. Write a concise analysis to OUTPUT_FILE.
 
 ### Output
 
-Write `OUTPUT_DIR/reflection.md` in this format:
+Write OUTPUT_FILE in this format:
+
+```markdown
+## <workflowName>: <displayTitle> (<conclusion>)
+
+- **run**: <databaseId> | **event**: <event> | **branch**: <headBranch>
+- **started**: <startedAt> | **conclusion**: <conclusion>
+
+### Summary
+
+1-3 sentence summary of what happened in this run.
+
+### Issue
+
+If a work run: issue number, title, verdict, PR link (if any).
+
+### Failures
+
+If failed: root cause, relevant log lines (keep brief).
+
+### Notes
+
+Anything notable: retries, feedback loops, unusual patterns.
+```
+
+Keep it concise — under 80 lines. Focus on what matters for the daily summary.
+
+---
+
+## Phase: summarize
+
+Combine per-run analyses into a final reflection. You are sandboxed with no network access.
+
+### Environment
+
+- `ANALYSIS_DIR` — directory containing per-run analysis files.
+- `DATE` — date string (YYYY-MM-DD).
+- `OUTPUT_FILE` — path to write the reflection.
+
+### Instructions
+
+1. Read all `*.md` files in ANALYSIS_DIR.
+2. Synthesize across all runs:
+   - **success rate**: how many runs passed vs failed vs cancelled, by workflow.
+   - **failure patterns**: common failure modes grouped by root cause.
+   - **work loop outcomes**: issues attempted, verdicts, PRs created.
+   - **patterns**: trends, flakiness, duration observations.
+   - **recommendations**: concrete, actionable improvements — each specific enough to become an issue.
+3. Write OUTPUT_FILE.
+
+### Output
+
+Write OUTPUT_FILE in this format:
 
 ```markdown
 # Reflection: YYYY-MM-DD
 
 ## Summary
 
-Brief overview of the period.
+Brief overview of the day.
 
 ## Runs
 
@@ -80,17 +138,17 @@ Brief overview of the period.
 
 ## Failure Analysis
 
-Group failures by root cause. Include relevant log excerpts.
+Group failures by root cause. Include brief log excerpts where helpful.
 
 ## Work Loop Outcomes
 
-Summarize issues attempted, verdicts, and PRs created.
+Issues attempted, verdicts, PRs created.
 
 ## Patterns
 
-Observations about trends, flakiness, duration.
+Trends, flakiness, duration.
 
 ## Recommendations
 
-Concrete, actionable improvements. Each should be specific enough to become an issue.
+Concrete improvements. Each should be specific enough to become an issue.
 ```


### PR DESCRIPTION
## Changes

Redesigns the reflect analyze phase to avoid stuffing all logs into one agent context.

### Per-run analysis
- one sandboxed agent per workflow run (instead of one agent for all runs)
- each agent reads only that run's log + artifacts, produces `o/reflect/analyze/<run-id>.md`
- keeps context small (~30k tokens max per agent)

### Artifact inspection
- analyze-run agents dig into downloaded artifacts:
  - `issue.json`, `reasoning.md` — what was picked
  - `plan.md` — what was planned
  - `actions.json` — verdict and actions
  - `feedback.md` — retry feedback
  - `session*.db` — session presence/size

### Summarize phase
- new phase after analyze: one agent reads all per-run analyses
- produces final `reflection.md` with cross-run synthesis

### Auth fix
- checkout action now uses `token: GH_TOKEN` so credential helper works for `git push`
- removes need for `git remote set-url` hack

### Pipeline shape
```
fetch → analyze (per-run, sequential) → summarize → publish
```

Fixes the `fetch failed: transport error` from overloaded context in previous runs.