### PR TITLE
fix reflect auth: use remote set-url for push

### DIFF
--- a/.github/workflows/reflect.yml
+++ b/.github/workflows/reflect.yml
@@ -24,8 +24,6 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          token: ${{ secrets.GH_TOKEN }}
 
       - name: Reflect
         env:

--- a/reflect.mk
+++ b/reflect.mk
@@ -124,6 +124,7 @@ $(publish_done): $(reflection)
 	@cp $(reflection) note/$(DATE)/reflection.md
 	@git add note/$(DATE)/reflection.md
 	@git commit -m "reflect: add $(DATE) reflection"
+	@git remote set-url origin https://x-access-token:$(GH_TOKEN)@github.com/$(REFLECT_REPO).git
 	@git push --force-with-lease -u origin $(reflect_branch)
 	@gh pr create \
 		--repo $(REFLECT_REPO) \


### PR DESCRIPTION
Fixes the checkout failure from #23.

The fine-grained PAT may not include `whilp/working` in its repo scope, so passing it to `actions/checkout` breaks the fetch. Revert to default `GITHUB_TOKEN` for checkout (always works for own repo) and use `x-access-token` remote URL for push, matching the `work.mk` pattern.