### PR TITLE
fix publish: unset checkout extraheader before push

### DIFF
--- a/reflect.mk
+++ b/reflect.mk
@@ -124,6 +124,7 @@ $(publish_done): $(reflection)
 	@cp $(reflection) note/$(DATE)/reflection.md
 	@git add note/$(DATE)/reflection.md
 	@git commit -m "reflect: add $(DATE) reflection"
+	@git config --unset-all http.https://github.com/.extraheader || true
 	@git remote set-url origin https://x-access-token:$(GH_TOKEN)@github.com/$(REFLECT_REPO).git
 	@git push --force-with-lease -u origin $(reflect_branch)
 	@gh pr create \


### PR DESCRIPTION
The `actions/checkout` action configures `http.https://github.com/.extraheader` with the default `GITHUB_TOKEN`, which takes precedence over URL-embedded credentials. This causes `git push` to use `github-actions[bot]` instead of the PAT.

Fix: `git config --unset-all http.https://github.com/.extraheader` before setting the remote URL with `GH_TOKEN`.