### PR TITLE
fix publish push: use git -c to override credential helper

### DIFF
--- a/reflect.mk
+++ b/reflect.mk
@@ -124,9 +124,9 @@ $(publish_done): $(reflection)
 	@cp $(reflection) note/$(DATE)/reflection.md
 	@git add note/$(DATE)/reflection.md
 	@git commit -m "reflect: add $(DATE) reflection"
-	@git config --unset-all http.https://github.com/.extraheader || true
-	@git remote set-url origin https://x-access-token:$(GH_TOKEN)@github.com/$(REFLECT_REPO).git
-	@git push --force-with-lease -u origin $(reflect_branch)
+	@git -c http.https://github.com/.extraheader= \
+		-c url.https://x-access-token:$(GH_TOKEN)@github.com/.insteadOf=https://github.com/ \
+		push --force-with-lease -u origin $(reflect_branch)
 	@gh pr create \
 		--repo $(REFLECT_REPO) \
 		--head $(reflect_branch) \


### PR DESCRIPTION
Use `git -c` flags on the push command to:
1. Clear the extraheader set by actions/checkout
2. Rewrite github.com URLs to use the PAT via `insteadOf`

This avoids mutating the repo's git config and handles the credential conflict in a single command.