### PR TITLE
simplify publish auth: use checkout token, plain git push

### DIFF
--- a/.github/workflows/reflect.yml
+++ b/.github/workflows/reflect.yml
@@ -24,6 +24,8 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Reflect
         env:

--- a/reflect.mk
+++ b/reflect.mk
@@ -124,9 +124,7 @@ $(publish_done): $(reflection)
 	@cp $(reflection) note/$(DATE)/reflection.md
 	@git add note/$(DATE)/reflection.md
 	@git commit -m "reflect: add $(DATE) reflection"
-	@git -c http.https://github.com/.extraheader= \
-		-c url.https://x-access-token:$(GH_TOKEN)@github.com/.insteadOf=https://github.com/ \
-		push --force-with-lease -u origin $(reflect_branch)
+	@git push --force-with-lease -u origin $(reflect_branch)
 	@gh pr create \
 		--repo $(REFLECT_REPO) \
 		--head $(reflect_branch) \


### PR DESCRIPTION
Removes all credential helper hacks from reflect.mk publish.

Uses `token: ${{ secrets.GH_TOKEN }}` on `actions/checkout` so the credential helper is pre-configured with the PAT. Plain `git push` then works.

**Requires**: `whilp/working` added to the `GH_TOKEN` fine-grained PAT's repo scope (#28).