### PR TITLE
fix publish: clone into separate dir for push

### DIFF
--- a/.github/workflows/reflect.yml
+++ b/.github/workflows/reflect.yml
@@ -24,8 +24,6 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          token: ${{ secrets.GH_TOKEN }}
 
       - name: Reflect
         env:


### PR DESCRIPTION
Clone `whilp/working` into `o/reflect/repo/` for the publish phase, matching `work.mk`'s proven pattern. The separate clone has no credential helper pollution from `actions/checkout`, so `remote set-url` with the PAT works cleanly for push.

Reverts the `token:` approach on checkout — the default `GITHUB_TOKEN` is fine for checkout (read-only on own repo).