### PR TITLE
use github app tokens instead of PAT in workflows

### DIFF
--- a/.github/workflows/reflect.yml
+++ b/.github/workflows/reflect.yml
@@ -29,7 +29,7 @@ jobs:
         id: app-token
         with:
           app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          private-key: ${{ secrets.APP_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ah,cosmic,working
 

--- a/.github/workflows/work.yml
+++ b/.github/workflows/work.yml
@@ -33,7 +33,7 @@ jobs:
         id: app-token
         with:
           app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          private-key: ${{ secrets.APP_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ah,cosmic,working
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ three secrets are required:
 
 - `CLAUDE_CODE_OAUTH_TOKEN` — oauth token for claude API access.
 - `APP_ID` — github app id.
-- `APP_PRIVATE_KEY` — PEM private key for the github app.
+- `APP_KEY` — PEM private key for the github app.
 
 the github app needs installation access to target repos (ah, cosmic, working) with these permissions:
 


### PR DESCRIPTION
replace static `GH_TOKEN` PAT secret with `actions/create-github-app-token` to generate fresh installation tokens at the start of each workflow run.

**changes:**
- work.yml: add token generation step, use output as `GH_TOKEN`
- reflect.yml: same
- AGENTS.md: update setup docs to reflect new secrets

**new secrets required:**
- `APP_ID` — github app id
- `APP_PRIVATE_KEY` — PEM private key for the github app

**removes:**
- `GH_TOKEN` secret (no longer needed)

the `GH_TOKEN` env var still exists — it's just populated from the generated token instead of a static secret. no changes needed to makefiles or tools.