### PR TITLE
fix: use graphql for pr queries to avoid gh cli repo context bug

### DIFF
--- a/skills/pick/tools/count-open-prs.tl
+++ b/skills/pick/tools/count-open-prs.tl
@@ -1,6 +1,7 @@
 -- skills/pick/tools/count-open-prs.tl: count open PRs on a repo
 --
--- reads WORK_REPO from environment to limit scope.
+-- uses graphql with explicit owner/name to avoid gh CLI local repo
+-- context issues. reads WORK_REPO from environment to limit scope.
 -- module tool: returns a Tool record for ah to load via -t
 
 local child = require("cosmic.child")
@@ -16,6 +17,16 @@ local function run(argv: {string}): boolean | string, string, number
   return h:read()
 end
 
+local QUERY = [[
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(states: OPEN) {
+      totalCount
+    }
+  }
+}
+]]
+
 local repo = os.getenv("WORK_REPO") or ""
 
 return {
@@ -30,16 +41,36 @@ return {
       return "error: WORK_REPO environment variable not set"
     end
 
-    local ok, out, code = run({"gh", "pr", "list", "--repo", repo, "--state", "open", "--json", "number"})
+    local owner, name = repo:match("^([^/]+)/([^/]+)$")
+    if not owner or not name then
+      return "error: WORK_REPO must be owner/name format"
+    end
+
+    local ok, out, code = run({
+        "gh", "api", "graphql",
+        "-f", "query=" .. QUERY,
+        "-f", "owner=" .. owner,
+        "-f", "name=" .. name,
+      })
     if not ok then
       return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
     end
 
-    local prs = json.decode(out or "[]") as {any}
-    if not prs then
-      return "error: failed to parse PR list"
+    local resp = json.decode(out or "{}") as {string: any}
+    if not resp or not resp.data then
+      local errors = resp and resp.errors as {any}
+      if errors and #errors > 0 then
+        local first = errors[1] as {string: any}
+        return "error: graphql: " .. tostring(first.message or "unknown")
+      end
+      return "error: failed to parse graphql response"
     end
 
-    return tostring(#prs)
+    local data = resp.data as {string: any}
+    local repository = data.repository as {string: any}
+    local prs_conn = repository.pullRequests as {string: any}
+    local count = prs_conn.totalCount as number
+
+    return tostring(math.floor(count))
   end,
 }

--- a/skills/pick/tools/get-prs-with-feedback.tl
+++ b/skills/pick/tools/get-prs-with-feedback.tl
@@ -1,7 +1,8 @@
 -- skills/pick/tools/get-prs-with-feedback.tl: list open PRs with review feedback
 --
 -- returns PRs where reviewDecision is CHANGES_REQUESTED, including their
--- review comments and details. combines listing and feedback into one call.
+-- review comments and details. uses graphql with explicit owner/name to
+-- avoid gh CLI local repo context issues.
 -- reads WORK_REPO from environment to limit scope.
 -- module tool: returns a Tool record for ah to load via -t
 
@@ -18,7 +19,45 @@ local function run(argv: {string}): boolean | string, string, number
   return h:read()
 end
 
+local QUERY = [[
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(first: 50, states: OPEN, orderBy: {field: UPDATED_AT, direction: ASC}) {
+      nodes {
+        number
+        title
+        url
+        headRefName
+        reviewDecision
+        updatedAt
+        body
+        reviews(last: 20) {
+          nodes {
+            author { login }
+            body
+            state
+            submittedAt
+          }
+        }
+        comments(last: 20) {
+          nodes {
+            author { login }
+            body
+            createdAt
+          }
+        }
+      }
+    }
+  }
+}
+]]
+
 local repo = os.getenv("WORK_REPO") or ""
+
+local function parse_repo(r: string): string, string
+  local owner, name = r:match("^([^/]+)/([^/]+)$")
+  return owner, name
+end
 
 return {
   name = "get_prs_with_feedback",
@@ -27,49 +66,86 @@ return {
     type = "object",
     properties = {},
   },
+  _parse_repo = parse_repo,
   execute = function(_: {string: any}): string
     if repo == "" then
       return "error: WORK_REPO environment variable not set"
     end
 
+    local owner, name = parse_repo(repo)
+    if not owner or not name then
+      return "error: WORK_REPO must be owner/name format"
+    end
+
     local ok, out, code = run({
-        "gh", "pr", "list",
-        "--repo", repo,
-        "--state", "open",
-        "--json", "number,title,url,headRefName,reviewDecision,updatedAt,body",
+        "gh", "api", "graphql",
+        "-f", "query=" .. QUERY,
+        "-f", "owner=" .. owner,
+        "-f", "name=" .. name,
       })
     if not ok then
       return "error: gh failed (exit " .. tostring(code) .. "): " .. (out or "")
     end
 
-    local prs = json.decode(out or "[]") as {{string: any}}
-    if not prs then
-      return "error: failed to parse PR list"
+    local resp = json.decode(out or "{}") as {string: any}
+    if not resp or not resp.data then
+      local errors = resp and resp.errors as {any}
+      if errors and #errors > 0 then
+        local first = errors[1] as {string: any}
+        return "error: graphql: " .. tostring(first.message or "unknown")
+      end
+      return "error: failed to parse graphql response"
     end
 
+    local data = resp.data as {string: any}
+    local repository = data.repository as {string: any}
+    local prs_conn = repository.pullRequests as {string: any}
+    local nodes = prs_conn.nodes as {any}
+
     local filtered: {any} = {}
-    for _, pr in ipairs(prs) do
+    for _, node_any in ipairs(nodes) do
+      local pr = node_any as {string: any}
       if pr.reviewDecision == "CHANGES_REQUESTED" then
-        -- fetch review comments for this PR
-        local num = pr.number as number
-        local rok, rout, rcode = run({
-            "gh", "pr", "view",
-            tostring(math.floor(num)),
-            "--repo", repo,
-            "--json", "number,title,body,headRefName,reviews,comments,reviewDecision,url,updatedAt",
-          })
-        if rok then
-          local detail = json.decode(rout or "{}") as {string: any}
-          if detail then
-            filtered[#filtered + 1] = detail
-          else
-            filtered[#filtered + 1] = pr
-          end
-        else
-          -- fall back to list data if view fails
-          pr._feedback_error = "gh pr view failed (exit " .. tostring(rcode) .. ")"
-          filtered[#filtered + 1] = pr
+        -- reshape reviews
+        local reviews_conn = pr.reviews as {string: any}
+        local review_nodes = reviews_conn and reviews_conn.nodes as {any} or {}
+        local reviews: {any} = {}
+        for _, r_any in ipairs(review_nodes) do
+          local r = r_any as {string: any}
+          local author = r.author as {string: any}
+          reviews[#reviews + 1] = {
+            author = author and author.login or nil,
+            body = r.body,
+            state = r.state,
+            submittedAt = r.submittedAt,
+          }
         end
+
+        -- reshape comments
+        local comments_conn = pr.comments as {string: any}
+        local comment_nodes = comments_conn and comments_conn.nodes as {any} or {}
+        local comments: {any} = {}
+        for _, c_any in ipairs(comment_nodes) do
+          local c = c_any as {string: any}
+          local author = c.author as {string: any}
+          comments[#comments + 1] = {
+            author = author and author.login or nil,
+            body = c.body,
+            createdAt = c.createdAt,
+          }
+        end
+
+        filtered[#filtered + 1] = {
+          number = pr.number,
+          title = pr.title,
+          body = pr.body,
+          url = pr.url,
+          headRefName = pr.headRefName,
+          reviewDecision = pr.reviewDecision,
+          updatedAt = pr.updatedAt,
+          reviews = reviews,
+          comments = comments,
+        }
       end
     end
 

--- a/skills/pick/tools/test_get_prs_with_feedback.tl
+++ b/skills/pick/tools/test_get_prs_with_feedback.tl
@@ -21,4 +21,30 @@ local function test_missing_env()
 end
 test_missing_env()
 
+local function test_parse_repo()
+  local parse = (tool as {string: any})._parse_repo as function(string): string, string
+  assert(parse, "should expose _parse_repo for testing")
+
+  local owner, name = parse("whilp/cosmic")
+  assert(owner == "whilp", "owner should be whilp: " .. tostring(owner))
+  assert(name == "cosmic", "name should be cosmic: " .. tostring(name))
+  print("✓ parse_repo splits owner/name correctly")
+
+  local o2, n2 = parse("invalid")
+  assert(o2 == nil, "should return nil for invalid format")
+  assert(n2 == nil, "should return nil for invalid format")
+  print("✓ parse_repo rejects invalid format")
+
+  local o3, n3 = parse("")
+  assert(o3 == nil, "should return nil for empty string")
+  assert(n3 == nil, "should return nil for empty string")
+  print("✓ parse_repo rejects empty string")
+
+  local o4, n4 = parse("a/b/c")
+  assert(o4 == nil, "should reject extra slashes: " .. tostring(o4))
+  assert(n4 == nil, "should reject extra slashes: " .. tostring(n4))
+  print("✓ parse_repo rejects extra slashes")
+end
+test_parse_repo()
+
 print("\nAll get_prs_with_feedback tests passed!")


### PR DESCRIPTION
## Problem

The work workflow's pick phase was returning PRs from the wrong repo. All three matrix jobs (whilp/ah, whilp/cosmic, whilp/working) returned whilp/working PR #37 data regardless of their `WORK_REPO` setting.

Root cause: `gh pr list --repo X` ignored the `--repo` flag in CI when run from a whilp/working checkout with a GitHub App installation token, falling back to the local git repo context.

This caused whilp/ah and whilp/cosmic jobs to fail at clone — they tried to checkout branch `work/35-a7f3c9e1` which only exists in whilp/working.

## Fix

Convert `get-prs-with-feedback.tl` and `count-open-prs.tl` from `gh pr list --repo` to `gh api graphql` with explicit `owner`/`name` variables. This matches the pattern `list-issues.tl` already uses successfully.

GraphQL queries address `repository(owner: $owner, name: $name)` directly, making them immune to local git context or token scope issues.

## Changes

- **get-prs-with-feedback.tl**: rewrite to use GraphQL. Fetches open PRs with reviews and comments in a single query, filters for `CHANGES_REQUESTED`. Exposes `_parse_repo` for testing.
- **count-open-prs.tl**: rewrite to use GraphQL with `totalCount` (no pagination needed).
- **test_get_prs_with_feedback.tl**: add `parse_repo` tests for owner/name extraction.

## Validation

```
make ci  # all checks pass
```