### PR TITLE
fix: read WORK_REPO at call time, add debug trace

### DIFF
--- a/skills/pick/tools/count-open-prs.tl
+++ b/skills/pick/tools/count-open-prs.tl
@@ -27,8 +27,6 @@ query($owner: String!, $name: String!) {
 }
 ]]
 
-local repo = os.getenv("WORK_REPO") or ""
-
 return {
   name = "count_open_prs",
   description = "Count the number of open pull requests on the target repository (set by WORK_REPO). Returns a number.",
@@ -37,14 +35,17 @@ return {
     properties = {},
   },
   execute = function(_: {string: any}): string
-    if repo == "" then
+    local live_repo = os.getenv("WORK_REPO") or ""
+    if live_repo == "" then
       return "error: WORK_REPO environment variable not set"
     end
 
-    local owner, name = repo:match("^([^/]+)/([^/]+)$")
+    local owner, name = live_repo:match("^([^/]+)/([^/]+)$")
     if not owner or not name then
       return "error: WORK_REPO must be owner/name format"
     end
+
+    io.stderr:write("count_open_prs: querying " .. owner .. "/" .. name .. "\n")
 
     local ok, out, code = run({
         "gh", "api", "graphql",

--- a/skills/pick/tools/get-prs-with-feedback.tl
+++ b/skills/pick/tools/get-prs-with-feedback.tl
@@ -52,8 +52,6 @@ query($owner: String!, $name: String!) {
 }
 ]]
 
-local repo = os.getenv("WORK_REPO") or ""
-
 local function parse_repo(r: string): string, string
   local owner, name = r:match("^([^/]+)/([^/]+)$")
   return owner, name
@@ -68,14 +66,18 @@ return {
   },
   _parse_repo = parse_repo,
   execute = function(_: {string: any}): string
-    if repo == "" then
+    -- read env at call time to avoid stale module-level capture
+    local live_repo = os.getenv("WORK_REPO") or ""
+    if live_repo == "" then
       return "error: WORK_REPO environment variable not set"
     end
 
-    local owner, name = parse_repo(repo)
+    local owner, name = parse_repo(live_repo)
     if not owner or not name then
-      return "error: WORK_REPO must be owner/name format"
+      return "error: WORK_REPO must be owner/name format: " .. live_repo
     end
+
+    io.stderr:write("get_prs_with_feedback: querying " .. owner .. "/" .. name .. "\n")
 
     local ok, out, code = run({
         "gh", "api", "graphql",


### PR DESCRIPTION
## Problem

The graphql fix (#42) didn't resolve the cross-repo contamination. All three matrix jobs still returned whilp/working PR data regardless of WORK_REPO setting. The graphql query uses explicit owner/name, so the only explanation is WORK_REPO itself is wrong at query time.

## Changes

- Move `os.getenv('WORK_REPO')` from module load time into `execute()` — rules out stale capture
- Add `io.stderr:write` debug lines showing which owner/name is being queried
- Remove unused module-level `repo` variable

This is a diagnostic commit. The stderr output will appear in the next workflow run logs and tell us definitively whether the env var is correct.