### PR TITLE
fix: reflect.mk clobbering WORK_REPO for all work jobs

### DIFF
--- a/reflect.mk
+++ b/reflect.mk
@@ -40,6 +40,8 @@ publish_done := $(o)/reflect/publish-done
 $(fetch_done): $(ah) $(cosmic)
 	@mkdir -p $(fetch_dir)
 	@echo "==> reflect: fetch runs $(SINCE)..$(UNTIL)"
+	# WORK_REPO is set inline, not globally — a global export would clobber
+	# work.mk's WORK_REPO := $(REPO) since reflect.mk is included second.
 	@WORK_REPO=$(REFLECT_REPO) timeout 300 $(ah) -n \
 		-m sonnet \
 		--skill reflect \


### PR DESCRIPTION
## problem

reflect.mk line 16 unconditionally sets `export WORK_REPO := $(REFLECT_REPO)` where `REFLECT_REPO` is hardcoded to `whilp/working`. since Makefile includes work.mk (line 114) then reflect.mk (line 115), reflect.mk's `:=` assignment clobbers work.mk's `export WORK_REPO := $(REPO)`.

all three matrix jobs (ah, cosmic, working) end up with `WORK_REPO=whilp/working` regardless of their `REPO` value.

## impact

- the ah job picked working issue #36 instead of an ah issue, went down a 41-turn research rabbit hole (989k input tokens), hit a transport error, and failed
- the cosmic job picked working issue #33 instead of a cosmic issue
- only the working job worked correctly (by accident)

## fix

remove the global `export WORK_REPO` from reflect.mk. set it as a per-recipe inline variable on the fetch recipe, which is the only reflect recipe that needs it (for `get-workflow-runs.tl`).