### PR TITLE
fix: use --repo flag instead of owner/repo#num for gh CLI

### DIFF
--- a/skills/act/tools/comment-issue.tl
+++ b/skills/act/tools/comment-issue.tl
@@ -45,12 +45,12 @@ return {
       return "error: body required"
     end
 
-    local ref = repo .. "#" .. tostring(math.floor(issue_number))
+    local num = tostring(math.floor(issue_number))
 
     local tmp = os.tmpname()
     cio.barf(tmp, body)
 
-    local ok, out, code = run({"gh", "issue", "comment", ref, "--body-file", tmp})
+    local ok, out, code = run({"gh", "issue", "comment", num, "--repo", repo, "--body-file", tmp})
     fs.unlink(tmp)
 
     if not ok then

--- a/skills/act/tools/set-issue-labels.tl
+++ b/skills/act/tools/set-issue-labels.tl
@@ -40,8 +40,8 @@ return {
       return "error: issue_number required"
     end
 
-    local ref = repo .. "#" .. tostring(math.floor(issue_number))
-    local argv: {string} = {"gh", "issue", "edit", ref}
+    local num = tostring(math.floor(issue_number))
+    local argv: {string} = {"gh", "issue", "edit", num, "--repo", repo}
 
     local add = input.add as {string}
     if add then

--- a/skills/pick/tools/set-issue-labels.tl
+++ b/skills/pick/tools/set-issue-labels.tl
@@ -40,8 +40,8 @@ return {
       return "error: issue_number required"
     end
 
-    local ref = repo .. "#" .. tostring(math.floor(issue_number))
-    local argv: {string} = {"gh", "issue", "edit", ref}
+    local num = tostring(math.floor(issue_number))
+    local argv: {string} = {"gh", "issue", "edit", num, "--repo", repo}
 
     local add = input.add as {string}
     if add then

--- a/skills/triage/tools/close-issue.tl
+++ b/skills/triage/tools/close-issue.tl
@@ -52,8 +52,8 @@ return {
       return "error: invalid reason: " .. reason .. " (must be completed or 'not planned')"
     end
 
-    local ref = repo .. "#" .. tostring(math.floor(issue_number))
-    local argv: {string} = {"gh", "issue", "close", ref, "--reason", reason}
+    local num = tostring(math.floor(issue_number))
+    local argv: {string} = {"gh", "issue", "close", num, "--repo", repo, "--reason", reason}
 
     local ok, out, code = run(argv)
     if not ok then


### PR DESCRIPTION
gh issue comment, gh issue edit, and gh issue close reject the owner/repo#number reference format. use `--repo owner/repo` with just the issue number as a positional arg, matching the pattern already used by create-pr.

**files fixed:**
- `skills/act/tools/comment-issue.tl`
- `skills/act/tools/set-issue-labels.tl`
- `skills/pick/tools/set-issue-labels.tl`
- `skills/triage/tools/close-issue.tl`

observed in work run [22085327380](https://github.com/whilp/working/actions/runs/22085327380) — comment_issue and set_issue_labels failed with `invalid issue format: "whilp/working#14"`.