### PR TITLE
skills: read target repo AGENTS.md in plan, do, check phases

### DIFF
--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -16,6 +16,9 @@ You are checking a work item. Review the execution against the plan.
 
 ## Setup
 
+Read `o/repo/AGENTS.md` if it exists. It contains repo-specific context,
+conventions, and build instructions for the target repository. Follow its guidance.
+
 Read `o/plan/plan.md` for the plan. Read `o/do/do.md` for the execution summary.
 
 ## Instructions

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -17,6 +17,9 @@ You are executing a work item. Follow the plan.
 
 ## Setup
 
+Read `o/repo/AGENTS.md` if it exists. It contains repo-specific context,
+conventions, and build instructions for the target repository. Follow its guidance.
+
 Read `o/plan/plan.md` for the full plan.
 
 Read `o/do/feedback.md` — if non-empty, it contains review feedback from a

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -16,6 +16,9 @@ You are planning a work item. Research the codebase and write a plan.
 
 ## Instructions
 
+First, read `o/repo/AGENTS.md` if it exists. It contains repo-specific context,
+conventions, and build instructions for the target repository. Follow its guidance.
+
 ### For PRs (type = "pr")
 
 1. Read the review comments in the `reviews` and `comments` fields.


### PR DESCRIPTION
## Problem

`ah` auto-loads `AGENTS.md` from `cwd`, which during the work workflow is the `working` repo root — not the target repo at `o/repo/`. The sandboxed phases (plan, do, check) never saw the target repo's `AGENTS.md` with its repo-specific context, conventions, and build instructions.

## Fix

Add explicit instructions to each skill's `SKILL.md` to read `o/repo/AGENTS.md` first:

- **plan**: added as first step in Instructions before researching
- **do**: added in Setup before reading `plan.md`
- **check**: added in Setup before reading `plan.md`/`do.md`

The target repo's `AGENTS.md` is already accessible via the existing `--unveil` permissions (`:rx` for plan/check, `:rwcx` for do).