### PR TITLE
reflect: incremental output, timeouts, skip analyzed

### DIFF
--- a/.github/workflows/reflect.yml
+++ b/.github/workflows/reflect.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   reflect:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     concurrency:
       group: reflect
       cancel-in-progress: false

--- a/skills/reflect/tools/analyze-runs.tl
+++ b/skills/reflect/tools/analyze-runs.tl
@@ -2,12 +2,13 @@
 --
 -- reads manifest.json from the fetch directory. spawns one ah agent per run.
 -- each agent produces an analysis markdown file.
+-- uses os.execute for incremental output in CI logs.
 --
 -- usage: cosmic skills/reflect/tools/analyze-runs.tl <fetch_dir> <analyze_dir> <ah_path>
 
-local child = require("cosmic.child")
 local json = require("cosmic.json")
 local cio = require("cosmic.io")
+local fs = require("cosmic.fs")
 
 local fetch_dir = arg[1]
 local analyze_dir = arg[2]
@@ -41,41 +42,64 @@ for _, entry in ipairs(manifest) do
 end
 
 print("  " .. tostring(#runs) .. " runs to analyze")
+io.flush()
+
+-- shell-escape a single argument
+local function quote(s: string): string
+  return "'" .. s:gsub("'", "'\\''") .. "'"
+end
 
 local failed = 0
+local skipped = 0
 for _, r in ipairs(runs) do
   local rid = tostring(r.databaseId as number)
   local out = analyze_dir .. "/" .. rid .. ".md"
   local run_dir = fetch_dir .. "/" .. rid
-  local meta = json.encode(r)
-  local stdin_str = "PHASE=analyze-run RUN_DIR=" .. run_dir .. " RUN_META=" .. meta .. " OUTPUT_FILE=" .. out
   local wf = r.workflowName as string or "?"
   local conclusion = r.conclusion as string or "?"
-  print("  -> " .. rid .. ": " .. wf .. " (" .. conclusion .. ")")
 
-  local h, err = child.spawn({
-      ah, "-n", "-m", "sonnet",
-      "--sandbox",
-      "--skill", "reflect",
-      "--must-produce", out,
-      "--max-tokens", "30000",
-      "--db", analyze_dir .. "/session-" .. rid .. ".db",
-      "--unveil", run_dir .. ":r",
-      "--unveil", analyze_dir .. ":rwc",
-      "--unveil", ".:r",
-    }, {
-      stdin = stdin_str,
-    })
-  if not h then
-    print("  !! " .. rid .. " spawn failed: " .. (err or "unknown"))
-    failed = failed + 1
+  -- skip if already analyzed
+  if fs.isfile(out) then
+    print("  -- " .. rid .. ": " .. wf .. " (skipped, already analyzed)")
+    io.flush()
+    skipped = skipped + 1
   else
-    local _, _, code = h:read()
-    if code ~= 0 then
+    print("  -> " .. rid .. ": " .. wf .. " (" .. conclusion .. ")")
+    io.flush()
+
+    -- write stdin to temp file for shell redirection
+    local meta = json.encode(r)
+    local stdin_str = "PHASE=analyze-run RUN_DIR=" .. run_dir .. " RUN_META=" .. meta .. " OUTPUT_FILE=" .. out
+    local _, stdin_path = fs.mkstemp("/tmp/ah-stdin-XXXXXX")
+    cio.barf(stdin_path, stdin_str)
+
+    -- run ah with inherited stdio for incremental output
+    -- timeout 60s per run — these are sandboxed read-only analyses
+    local cmd = "timeout 60 " .. quote(ah)
+    .. " -n -m sonnet"
+    .. " --sandbox"
+    .. " --skill reflect"
+    .. " --must-produce " .. quote(out)
+    .. " --max-tokens 30000"
+    .. " --db " .. quote(analyze_dir .. "/session-" .. rid .. ".db")
+    .. " --unveil " .. quote(run_dir .. ":r")
+    .. " --unveil " .. quote(analyze_dir .. ":rwc")
+    .. " --unveil .:r"
+    .. " < " .. quote(stdin_path)
+
+    local ok, _, code = os.execute(cmd)
+    fs.unlink(stdin_path)
+
+    if not ok then
       print("  !! " .. rid .. " failed (exit " .. tostring(code) .. ")")
+      io.flush()
       failed = failed + 1
     end
   end
 end
 
-print("  done: " .. tostring(#runs - failed) .. "/" .. tostring(#runs) .. " succeeded")
+local analyzed = #runs - failed - skipped
+print("  done: " .. tostring(analyzed) .. " analyzed, "
+  .. tostring(skipped) .. " skipped, "
+  .. tostring(failed) .. " failed"
+  .. " (of " .. tostring(#runs) .. ")")


### PR DESCRIPTION
follow-up to #59. the teal rewrite fixed the SyntaxError but the reflect run still failed — cancelled at the 15-minute job timeout because analyzing 57 runs sequentially takes too long.

changes:

- **workflow timeout**: 15 → 30 minutes.
- **incremental output**: `analyze-runs.tl` uses `os.execute` instead of `child.spawn` so each ah agent's output streams to CI logs immediately. no more 13-minute silent gap.
- **per-run timeout**: 60s per analyze-run agent via `timeout(1)`.
- **skip analyzed**: if a run's `.md` already exists, skip it. makes reruns idempotent.
- **io.flush**: after each status line for immediate CI visibility.
- **temp file cleanup**: uses `fs.mkstemp` + `fs.unlink` for stdin files.