### PR TITLE
reflect: increase workflow timeout to 45 minutes

### DIFF
--- a/.github/workflows/reflect.yml
+++ b/.github/workflows/reflect.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   reflect:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     concurrency:
       group: reflect
       cancel-in-progress: false


### PR DESCRIPTION
the 2026-02-16 reflection completed in ~29 minutes, just under the 30-minute limit. busier days with more runs will exceed it. 45 minutes gives comfortable headroom.