### PR TITLE
reflect: only analyze work workflow runs

### DIFF
--- a/reflect.mk
+++ b/reflect.mk
@@ -50,7 +50,7 @@ $(fetch_done): $(ah) $(cosmic)
 		--db $(fetch_dir)/session.db \
 		--tool "get_workflow_runs=skills/reflect/tools/get-workflow-runs.tl" \
 		--tool "bash=" \
-		<<< "PHASE=fetch SINCE=$(SINCE) UNTIL=$(UNTIL) OUTPUT_DIR=$(fetch_dir)"
+		<<< "PHASE=fetch SINCE=$(SINCE) UNTIL=$(UNTIL) OUTPUT_DIR=$(fetch_dir) WORKFLOW=work"
 
 .PHONY: fetch
 fetch: $(fetch_done)

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -18,6 +18,7 @@ Download workflow run logs and artifacts for a date range.
 - `SINCE` — start date (YYYY-MM-DD).
 - `UNTIL` — end date inclusive (YYYY-MM-DD).
 - `OUTPUT_DIR` — directory to write fetched data into.
+- `WORKFLOW` — workflow name to filter by (optional).
 
 ### Instructions
 
@@ -26,6 +27,7 @@ Download workflow run logs and artifacts for a date range.
    - `since` set to SINCE
    - `until_` set to UNTIL
    - `output_dir` set to OUTPUT_DIR
+   - `workflow` set to WORKFLOW (if provided)
 2. The tool downloads logs and artifacts for each run into OUTPUT_DIR.
 3. Verify the manifest file exists at `OUTPUT_DIR/manifest.json`.
 4. Write `OUTPUT_DIR/fetch-done` containing the number of runs fetched.


### PR DESCRIPTION
the reflection was fetching and analyzing all workflow runs — test CI, reflect, and work. test runs are trivial (pass/fail in ~13s, no meaningful content). reflect runs analyzing themselves is circular.

filter to `work` workflow only. these are the runs with issues picked, plans made, code written, and PRs opened — the actual outcomes worth reflecting on.

the 2026-02-16 reflection had 66 runs: 38 test, 9 reflect, 8 work. this cuts analysis from ~66 to ~8 runs, saving ~20 minutes of agent time.