### PR TITLE
embed env.d into ah binary

### DIFF
--- a/.github/workflows/reflect.yml
+++ b/.github/workflows/reflect.yml
@@ -25,9 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Create embed env.d placeholder
-        run: touch embed/env.d/20-claude
-
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: app-token
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,5 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Create embed env.d placeholder
-        run: touch embed/env.d/20-claude
-
       - name: Run type checks and format checks
         run: make -j ci

--- a/.github/workflows/work.yml
+++ b/.github/workflows/work.yml
@@ -29,9 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Create embed env.d placeholder
-        run: touch embed/env.d/20-claude
-
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: app-token
         with:

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,15 @@ $(ah_raw): deps/ah.mk
 	@echo "$(ah_sha)  $@" | sha256sum -c - >/dev/null
 	@chmod +x $@
 
+embed/env.d/20-claude:
+ifdef CI
+	@touch $@
+else ifdef CLAUDE_CODE_OAUTH_TOKEN
+	@echo "CLAUDE_CODE_OAUTH_TOKEN=$(CLAUDE_CODE_OAUTH_TOKEN)" > $@
+else
+	@echo "error: $@ not found — create it with your env vars" >&2; exit 1
+endif
+
 $(ah): $(ah_raw) embed/env.d/20-claude
 	@echo "==> embedding env.d into ah"
 	@$(ah_raw) -o $@ embed embed


### PR DESCRIPTION
embed env vars into the ah binary using the new `ah embed` feature.

## changes

- **embed/env.d/** — gitkeep tracked, contents gitignored
- **Makefile** — split ah fetch into `ah_raw` + embed step; `embed/env.d/20-claude` rule handles three cases:
  - CI: touch empty placeholder
  - local + `CLAUDE_CODE_OAUTH_TOKEN` in env: generate file from env var
  - local + no env var + no file: error with guidance
- **deps/ah.mk** — bump to 2026-02-17-e802a1e (supports envd embedding)

also filed whilp/ah#384 for the `--output` flag ordering confusion discovered during this work.