### PR TITLE
docs: add branch and commit message conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,8 +107,10 @@ skills/               agent skills and their tools
 
 ## making changes
 
-1. read the relevant skill SKILL.md and tool .tl files before editing.
-2. every tool .tl file must have a corresponding test_*.tl file.
-3. run `make ci` before committing. all checks must pass.
-4. tool modules return a table with `name`, `description`, `input_schema`, `execute`.
-5. tests validate tool record structure and input validation (no external calls).
+1. before starting work on a new problem, check the current branch with `git branch --show-current`. if on `main` (or another default branch), create and switch to a new feature branch (e.g. `git checkout -b issue-<number>-<short-description>`). never commit directly to `main`.
+2. read the relevant skill SKILL.md and tool .tl files before editing.
+3. every tool .tl file must have a corresponding test_*.tl file.
+4. run `make ci` before committing. all checks must pass.
+5. use `component: action` format for commit messages and PR titles (e.g. `pick: add priority sorting`, `docs: update setup instructions`). lowercase, imperative. common components: skill names (`pick`, `plan`, `do`, `check`, `act`, `reflect`, `triage`), `docs`, `ci`, `tools`.
+6. tool modules return a table with `name`, `description`, `input_schema`, `execute`.
+7. tests validate tool record structure and input validation (no external calls).

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -81,7 +81,17 @@ skills define:
 
 ## commits
 
-commit messages are lowercase, imperative. first line is a short summary. body explains why, not what.
+use `component: action` format for commit messages and PR titles. lowercase, imperative.
+
+examples:
+- `pick: add priority sorting`
+- `docs: update setup instructions`
+- `ci: fix test runner path`
+- `reflect: handle missing workflow runs`
+
+common components: skill names (`pick`, `plan`, `do`, `check`, `act`, `reflect`, `triage`), `docs`, `ci`, `tools`.
+
+first line is a short summary. body explains why, not what.
 
 ## error handling
 


### PR DESCRIPTION
adds two pieces of guidance to AGENTS.md and docs/conventions.md:

- **branch before working**: agents must check the current branch and create a new feature branch if on `main` before starting work. never commit directly to `main`.
- **commit message format**: use `component: action` format for commit messages and PR titles. lowercase, imperative. lists common components (skill names, `docs`, `ci`, `tools`) with examples.