### PR TITLE
pick: filter PRs with needs-review label to prevent re-iteration

### DIFF
--- a/docs/work.md
+++ b/docs/work.md
@@ -12,7 +12,7 @@ each phase is a make target with file-based dependencies. outputs go to `o/`.
 
 ## phases
 
-**pick** — selects the next work item. first checks for open PRs with `CHANGES_REQUESTED` review status. if found, picks the oldest one. otherwise, selects one open `todo`-labeled issue. ensures labels exist, checks PR limits, picks by priority/age/clarity. transitions issues to `doing`. writes `o/pick/issue.json` with a `type` field (`"pr"` or `"issue"`).
+**pick** — selects the next work item. first checks for open PRs with `CHANGES_REQUESTED` review status (excluding PRs labeled `needs-review`, which are waiting for the reviewer). if found, picks the oldest one. otherwise, selects one open `todo`-labeled issue. ensures labels exist, checks PR limits, picks by priority/age/clarity. transitions issues to `doing`. writes `o/pick/issue.json` with a `type` field (`"pr"` or `"issue"`).
 
 **clone** — clones (or fetches) the target repo into `o/repo/`. for PRs, checks out the existing branch. for issues, creates a fresh feature branch from the default branch.
 
@@ -24,7 +24,7 @@ each phase is a make target with file-based dependencies. outputs go to `o/`.
 
 **check** — reviews the diff against the plan. for PRs, verifies each piece of feedback was addressed. writes verdict (`pass`, `needs-fixes`, `fail`) and actions to `o/check/actions.json`.
 
-**act** — executes actions: comments on the issue/PR, creates a PR (on pass, for issues only), transitions labels to `done` or `failed` (for issues only). writes `o/act.json`.
+**act** — executes actions: comments on the issue/PR, creates a PR (on pass, for issues only), transitions labels to `done` or `failed` (for issues) or `needs-review` (for PRs). writes `o/act.json`.
 
 ## convergence
 
@@ -42,10 +42,10 @@ each phase runs `ah` (the agent harness) with:
 ## tools
 
 **pick tools** (`skills/pick/tools/`):
-- `get-prs-with-feedback.tl` — list open PRs with `CHANGES_REQUESTED` review status and their review comments via `gh pr list` and `gh pr view`
+- `get-prs-with-feedback.tl` — list open PRs with `CHANGES_REQUESTED` review status (excluding `needs-review` labeled PRs) and their review comments via GraphQL
 - `list-issues.tl` — fetch open `todo` issues via `gh issue list`
 - `count-open-prs.tl` — count open PRs via `gh pr list`
-- `ensure-labels.tl` — create `todo`/`doing`/`done`/`failed` labels via `gh label create`
+- `ensure-labels.tl` — create `todo`/`doing`/`done`/`failed`/`needs-review` labels via `gh label create`
 - `set-issue-labels.tl` — add/remove labels via `gh issue edit`
 
 **act tools** (`skills/act/tools/`):

--- a/skills/act/SKILL.md
+++ b/skills/act/SKILL.md
@@ -25,7 +25,7 @@ You are executing the actions produced by the check phase of a work pipeline.
    - If `type` is `"issue"`:
      - If verdict is "pass" AND all actions succeeded: run `set_issue_labels` with `issue_number`, remove `doing`, add `done`.
      - Otherwise: run `set_issue_labels` with `issue_number`, remove `doing`, add `failed`.
-   - If `type` is `"pr"`: do not transition labels (PR feedback was addressed, reviewer will re-review).
+   - If `type` is `"pr"`: run `set_issue_labels` with `issue_number` (the PR number), add `needs-review`. This prevents the pick phase from re-selecting this PR until the reviewer acts.
 
 ## Output
 
@@ -37,6 +37,6 @@ Write `o/act.json`:
   "verdict": "<pass|needs-fixes|fail>",
   "actions_executed": <count>,
   "actions_failed": <count>,
-  "label": "<done|failed|none>"
+  "label": "<done|failed|needs-review>"
 }
 ```

--- a/skills/pick/tools/ensure-labels.tl
+++ b/skills/pick/tools/ensure-labels.tl
@@ -19,7 +19,7 @@ local repo = os.getenv("WORK_REPO") or ""
 
 return {
   name = "ensure_labels",
-  description = "Ensure required labels exist on the target repository (set by WORK_REPO). Defaults to work labels (todo, doing, done, failed) if no labels specified.",
+  description = "Ensure required labels exist on the target repository (set by WORK_REPO). Defaults to work labels (todo, doing, done, failed, needs-review) if no labels specified.",
   input_schema = {
     type = "object",
     properties = {
@@ -32,7 +32,7 @@ return {
     end
 
     local custom = input.labels as {string}
-    local labels: {string} = (custom and #custom > 0) and custom or {"todo", "doing", "done", "failed"}
+    local labels: {string} = (custom and #custom > 0) and custom or {"todo", "doing", "done", "failed", "needs-review"}
     local errors: {string} = {}
     for _, label in ipairs(labels) do
       local ok, out = run({"gh", "label", "create", label, "--repo", repo, "--force"})

--- a/skills/pick/tools/get-prs-with-feedback.tl
+++ b/skills/pick/tools/get-prs-with-feedback.tl
@@ -1,8 +1,9 @@
 -- skills/pick/tools/get-prs-with-feedback.tl: list open PRs with review feedback
 --
--- returns PRs where reviewDecision is CHANGES_REQUESTED, including their
--- review comments and details. uses graphql with explicit owner/name to
--- avoid gh CLI local repo context issues.
+-- returns PRs where reviewDecision is CHANGES_REQUESTED and not labeled
+-- needs-review. PRs with needs-review were already addressed and are waiting
+-- for the reviewer. uses graphql with explicit owner/name to avoid gh CLI
+-- local repo context issues.
 -- reads WORK_REPO from environment to limit scope.
 -- module tool: returns a Tool record for ah to load via -t
 
@@ -31,6 +32,11 @@ query($owner: String!, $name: String!) {
         reviewDecision
         updatedAt
         body
+        labels(first: 20) {
+          nodes {
+            name
+          }
+        }
         reviews(last: 20) {
           nodes {
             author { login }
@@ -59,7 +65,7 @@ end
 
 return {
   name = "get_prs_with_feedback",
-  description = "List open pull requests that have CHANGES_REQUESTED review status, including their review comments. Returns a JSON array of PRs with feedback details. Operates on the repo set by WORK_REPO environment variable.",
+  description = "List open pull requests that have CHANGES_REQUESTED review status and are not labeled needs-review. Returns a JSON array of PRs with feedback details. PRs labeled needs-review were already addressed and are waiting for the reviewer. Operates on the repo set by WORK_REPO environment variable.",
   input_schema = {
     type = "object",
     properties = {},
@@ -107,7 +113,21 @@ return {
     local filtered: {any} = {}
     for _, node_any in ipairs(nodes) do
       local pr = node_any as {string: any}
-      if pr.reviewDecision == "CHANGES_REQUESTED" then
+      -- skip PRs labeled needs-review (already addressed, waiting for reviewer)
+      local has_needs_review = false
+      local labels_conn = pr.labels as {string: any}
+      if labels_conn then
+        local label_nodes = labels_conn.nodes as {any} or {}
+        for _, l_any in ipairs(label_nodes) do
+          local l = l_any as {string: any}
+          if l.name == "needs-review" then
+            has_needs_review = true
+            break
+          end
+        end
+      end
+
+      if pr.reviewDecision == "CHANGES_REQUESTED" and not has_needs_review then
         -- reshape reviews
         local reviews_conn = pr.reviews as {string: any}
         local review_nodes = reviews_conn and reviews_conn.nodes as {any} or {}


### PR DESCRIPTION
Closes #69

## Problem

PR #61 was re-iterated 20+ times by the agent. After addressing review feedback and pushing, the PR still has `CHANGES_REQUESTED` status (only the human reviewer can change that). The act phase didn't add any label to PRs, so the next hourly run picked the same PR again.

## Solution

Use a `needs-review` label to track PR state:

1. **`get-prs-with-feedback.tl`** — GraphQL query now fetches labels. Filters out PRs labeled `needs-review` (already addressed, waiting for reviewer).
2. **`ensure-labels.tl`** — adds `needs-review` to the default label set.
3. **`act SKILL.md`** — after acting on a PR, adds `needs-review` label. This prevents pick from re-selecting the PR.
4. **`docs/work.md`** — updated phase descriptions and tool docs.

## Flow

1. Reviewer requests changes → PR has `CHANGES_REQUESTED`, no `needs-review`
2. Agent picks PR, addresses feedback, pushes, acts → adds `needs-review`
3. Next run: tool filters out PR (has `needs-review`) → agent works on something else
4. Reviewer removes `needs-review` when ready for another iteration

## Validation

```
make ci  # 13 type checks, 13 format checks, 12 tests: all pass
```