### PR TITLE
pick: include PRs with failing CI checks in iteration

### DIFF
--- a/docs/work.md
+++ b/docs/work.md
@@ -6,13 +6,13 @@ the system implements a PDCA (plan-do-check-act) loop for github issues and PR f
 pick → clone → plan → do → push → check → act
 ```
 
-pick prefers PRs with review feedback over new issues. when a PR has `CHANGES_REQUESTED` status, the pipeline addresses that feedback. otherwise, it picks a new issue.
+pick prefers PRs with review feedback or failing CI checks over new issues. when a PR has `CHANGES_REQUESTED` status or failing checks, the pipeline addresses that. otherwise, it picks a new issue.
 
 each phase is a make target with file-based dependencies. outputs go to `o/`.
 
 ## phases
 
-**pick** — selects the next work item. first checks for open PRs with `CHANGES_REQUESTED` review status (excluding PRs labeled `needs-review`, which are waiting for the reviewer). if found, picks the oldest one. otherwise, selects one open `todo`-labeled issue. ensures labels exist, checks PR limits, picks by priority/age/clarity. transitions issues to `doing`. writes `o/pick/issue.json` with a `type` field (`"pr"` or `"issue"`).
+**pick** — selects the next work item. first checks for open PRs that need attention: `CHANGES_REQUESTED` review status or failing CI checks (excluding PRs labeled `needs-review`, which are waiting for the reviewer). if found, picks the oldest one. otherwise, selects one open `todo`-labeled issue. ensures labels exist, checks PR limits, picks by priority/age/clarity. transitions issues to `doing`. writes `o/pick/issue.json` with a `type` field (`"pr"` or `"issue"`) and, for PRs, a `reason` field indicating why it was selected.
 
 **clone** — clones (or fetches) the target repo into `o/repo/`. for PRs, checks out the existing branch. for issues, creates a fresh feature branch from the default branch.
 
@@ -42,7 +42,7 @@ each phase runs `ah` (the agent harness) with:
 ## tools
 
 **pick tools** (`skills/pick/tools/`):
-- `get-prs-with-feedback.tl` — list open PRs with `CHANGES_REQUESTED` review status (excluding `needs-review` labeled PRs) and their review comments via GraphQL
+- `get-prs-with-feedback.tl` — list open PRs needing attention: `CHANGES_REQUESTED` review status or failing CI checks (excluding `needs-review` labeled PRs) via GraphQL. includes a `reason` field.
 - `list-issues.tl` — fetch open `todo` issues via `gh issue list`
 - `count-open-prs.tl` — count open PRs via `gh pr list`
 - `ensure-labels.tl` — create `todo`/`doing`/`done`/`failed`/`needs-review` labels via `gh label create`

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -11,7 +11,7 @@ You are checking a work item. Review the execution against the plan.
 
 - The target repository is at `o/repo/`.
 - The work item JSON follows this prompt after `---`.
-- If `type` is `"pr"`, you are checking that review feedback was addressed.
+- If `type` is `"pr"`, you are checking that review feedback and/or CI failures were addressed (check the `reason` field).
 - If `type` is `"issue"`, you are checking new work against the plan.
 
 ## Setup
@@ -29,7 +29,7 @@ Read `o/plan/plan.md` for the plan. Read `o/do/do.md` for the execution summary.
    ```
 2. Run validation steps from the plan.
 3. Check for unintended changes.
-4. For PRs: verify each piece of review feedback was addressed.
+4. For PRs: verify each piece of review feedback was addressed and/or CI checks now pass (based on `reason` field).
 5. Write your assessment.
 
 ## Output

--- a/skills/pick/SKILL.md
+++ b/skills/pick/SKILL.md
@@ -15,9 +15,9 @@ You are selecting the next work item from a GitHub repository. PRs with review f
 
 1. Run `ensure_labels` (no arguments needed — reads repo from environment).
 2. Run `get_prs_with_feedback` (no arguments needed).
-3. If there are PRs with `CHANGES_REQUESTED`:
+3. If there are PRs needing attention (changes requested or failing CI checks):
    a. Pick the PR with the oldest `updatedAt` (longest waiting for attention).
-   b. Write your output with `type` set to `"pr"` and the PR details.
+   b. Write your output with `type` set to `"pr"` and the PR details. Include the `reason` field from the tool result.
    c. Skip the remaining steps.
 4. Run `count_open_prs` (no arguments needed). If more than 4, write `o/pick/issue.json` with `{"error": "pr_limit"}` and stop.
 5. Run `list_issues` (no arguments needed) to get open issues (returns issues labeled `todo` plus issues filed by repo collaborators).
@@ -44,6 +44,7 @@ For a PR with feedback:
   "body": "...",
   "url": "https://github.com/owner/repo/pull/123",
   "branch": "<headRefName from PR>",
+  "reason": "<changes_requested|checks_failing|changes_requested,checks_failing>",
   "reviews": [...],
   "comments": [...]
 }

--- a/skills/pick/tools/get-prs-with-feedback.tl
+++ b/skills/pick/tools/get-prs-with-feedback.tl
@@ -1,10 +1,12 @@
--- skills/pick/tools/get-prs-with-feedback.tl: list open PRs with review feedback
+-- skills/pick/tools/get-prs-with-feedback.tl: list open PRs needing attention
 --
--- returns PRs where reviewDecision is CHANGES_REQUESTED and not labeled
--- needs-review. PRs with needs-review were already addressed and are waiting
--- for the reviewer. uses graphql with explicit owner/name to avoid gh CLI
--- local repo context issues.
--- reads WORK_REPO from environment to limit scope.
+-- returns PRs that are blocked and need work: either reviewDecision is
+-- CHANGES_REQUESTED, or CI checks are failing. excludes PRs labeled
+-- needs-review (already addressed, waiting for reviewer). each returned PR
+-- includes a "reason" field: "changes_requested", "checks_failing", or
+-- "changes_requested,checks_failing".
+-- uses graphql with explicit owner/name to avoid gh CLI local repo context
+-- issues. reads WORK_REPO from environment to limit scope.
 -- module tool: returns a Tool record for ah to load via -t
 
 local child = require("cosmic.child")
@@ -37,6 +39,15 @@ query($owner: String!, $name: String!) {
             name
           }
         }
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup {
+                state
+              }
+            }
+          }
+        }
         reviews(last: 20) {
           nodes {
             author { login }
@@ -65,7 +76,7 @@ end
 
 return {
   name = "get_prs_with_feedback",
-  description = "List open pull requests that have CHANGES_REQUESTED review status and are not labeled needs-review. Returns a JSON array of PRs with feedback details. PRs labeled needs-review were already addressed and are waiting for the reviewer. Operates on the repo set by WORK_REPO environment variable.",
+  description = "List open pull requests that need attention: CHANGES_REQUESTED review status or failing CI checks. Excludes PRs labeled needs-review (already addressed, waiting for reviewer). Each PR includes a reason field. Operates on the repo set by WORK_REPO environment variable.",
   input_schema = {
     type = "object",
     properties = {},
@@ -115,6 +126,7 @@ return {
       local pr = node_any as {string: any}
       -- skip PRs labeled needs-review (already addressed, waiting for reviewer)
       local has_needs_review = false
+      local has_changes_requested = false
       local labels_conn = pr.labels as {string: any}
       if labels_conn then
         local label_nodes = labels_conn.nodes as {any} or {}
@@ -127,7 +139,41 @@ return {
         end
       end
 
-      if pr.reviewDecision == "CHANGES_REQUESTED" and not has_needs_review then
+      if pr.reviewDecision == "CHANGES_REQUESTED" then
+        has_changes_requested = true
+      end
+
+      -- check CI status from last commit
+      local has_checks_failing = false
+      local commits_conn = pr.commits as {string: any}
+      if commits_conn then
+        local commit_nodes = commits_conn.nodes as {any} or {}
+        if #commit_nodes > 0 then
+          local last_commit_node = commit_nodes[#commit_nodes] as {string: any}
+          local commit_obj = last_commit_node.commit as {string: any}
+          if commit_obj then
+            local rollup = commit_obj.statusCheckRollup as {string: any}
+            if rollup then
+              local state = rollup.state as string
+              if state == "FAILURE" or state == "ERROR" then
+                has_checks_failing = true
+              end
+            end
+          end
+        end
+      end
+
+      if (has_changes_requested or has_checks_failing) and not has_needs_review then
+        -- build reason string
+        local reasons: {string} = {}
+        if has_changes_requested then
+          reasons[#reasons + 1] = "changes_requested"
+        end
+        if has_checks_failing then
+          reasons[#reasons + 1] = "checks_failing"
+        end
+        local reason = table.concat(reasons, ",")
+
         -- reshape reviews
         local reviews_conn = pr.reviews as {string: any}
         local review_nodes = reviews_conn and reviews_conn.nodes as {any} or {}
@@ -165,6 +211,7 @@ return {
           headRefName = pr.headRefName,
           reviewDecision = pr.reviewDecision,
           updatedAt = pr.updatedAt,
+          reason = reason,
           reviews = reviews,
           comments = comments,
         }

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -21,10 +21,13 @@ conventions, and build instructions for the target repository. Follow its guidan
 
 ### For PRs (type = "pr")
 
-1. Read the review comments in the `reviews` and `comments` fields.
-2. Read relevant files referenced in the feedback.
-3. Identify what changes are requested by each reviewer comment.
-4. Write a plan that addresses each piece of feedback.
+1. Check the `reason` field to understand why this PR needs attention:
+   - `changes_requested`: reviewers requested changes. Read the `reviews` and `comments` fields.
+   - `checks_failing`: CI checks are failing. Run the repo's CI/test commands to reproduce failures.
+   - `changes_requested,checks_failing`: both. Address review feedback and fix CI failures.
+2. Read relevant files referenced in the feedback or failing tests.
+3. Identify what changes are needed.
+4. Write a plan that addresses each piece of feedback and/or fixes each CI failure.
 
 ### For Issues (type = "issue")
 

--- a/work.mk
+++ b/work.mk
@@ -3,9 +3,10 @@
 # implements the PDCA work loop as make targets:
 #   pick -> clone -> plan -> do -> push -> check -> act
 #
-# pick prefers PRs with review feedback over new issues. when a PR with
-# CHANGES_REQUESTED is found, pick selects it and the rest of the pipeline
-# addresses the feedback. otherwise, pick selects a new issue.
+# pick prefers PRs with review feedback or failing CI checks over new issues.
+# when a PR with CHANGES_REQUESTED or failing checks is found, pick selects
+# it and the rest of the pipeline addresses the feedback. otherwise, pick
+# selects a new issue.
 #
 # convergence: check writes o/do/feedback.md when verdict is needs-fixes.
 # since do depends on feedback.md, the next make run re-executes do -> push -> check.


### PR DESCRIPTION
## Summary

The work loop now considers all blocked PRs during iteration, not just those with `CHANGES_REQUESTED` review status. PRs with failing CI checks (FAILURE or ERROR `statusCheckRollup` state) are also picked up for fixing.

## Changes

- **`skills/pick/tools/get-prs-with-feedback.tl`** — added `commits(last: 1) { ... statusCheckRollup { state } }` to the GraphQL query. filter logic now includes PRs with failing checks. each returned PR includes a `reason` field: `changes_requested`, `checks_failing`, or `changes_requested,checks_failing`.
- **`skills/pick/SKILL.md`** — updated step 3 to mention failing CI checks. added `reason` field to PR output schema.
- **`skills/plan/SKILL.md`** — plan phase now checks `reason` field and reproduces CI failures when `checks_failing`.
- **`skills/check/SKILL.md`** — check phase verifies CI fixes based on `reason` field.
- **`docs/work.md`** — updated pick phase description and tool documentation.
- **`work.mk`** — updated header comments.

## How it works

The `statusCheckRollup.state` field on the last commit of each PR is one of: `EXPECTED`, `ERROR`, `FAILURE`, `PENDING`, `SUCCESS`. PRs with `FAILURE` or `ERROR` are now included alongside `CHANGES_REQUESTED` PRs. The `needs-review` label exclusion still applies to both.

Closes #70