### PR TITLE
work: switch plan and do from opus to sonnet 4.6

### DIFF
--- a/deps/ah.mk
+++ b/deps/ah.mk
@@ -1,2 +1,2 @@
-ah_url := https://github.com/whilp/ah/releases/download/2026-02-17-e802a1e/ah
-ah_sha := 729721967565a2859c04844868e16d9f5fafc05cdf8dc4eeeaafbbcbc020df0d
+ah_url := https://github.com/whilp/ah/releases/download/2026-02-18-0f7fca3/ah
+ah_sha := e5dbd26ece40c6c00764dae809e2c8a492719affdd6b6e52228084b783b85a00

--- a/work.mk
+++ b/work.mk
@@ -101,7 +101,7 @@ $(plan): $(repo_ready) $(issue) $(ah)
 	@echo "==> plan"
 	@mkdir -p $(plan_dir)
 	@timeout 180 $(ah) -n \
-		-m opus \
+		-m sonnet \
 		--sandbox \
 		--skill plan \
 		--must-produce $(plan) \
@@ -129,7 +129,7 @@ $(do_done): $(repo_ready) $(plan) $(feedback) $(issue) $(ah)
 		git -C $(repo_dir) reset --hard $(default_branch); \
 	fi
 	@timeout 300 $(ah) -n \
-		-m opus \
+		-m sonnet \
 		--sandbox \
 		--skill do \
 		--must-produce $(do_dir)/do.md \


### PR DESCRIPTION
switches plan and do phases from opus to sonnet. all phases now use sonnet consistently.

## changes

- `work.mk`: plan phase `-m opus` → `-m sonnet`
- `work.mk`: do phase `-m opus` → `-m sonnet`
- `deps/ah.mk`: bump ah to 2026-02-18-0f7fca3

## 1M context

1M context support requires whilp/ah#391 (add `claude-sonnet-4-6-1m` model and `sonnet-1m` alias). once that's released, a follow-up PR can switch heavyweight phases to `-m sonnet-1m`.

sonnet 4.6 base (200k context) is available now via whilp/ah#388.