### PR TITLE
pick: detect merge conflicts and rebase PR branches

### DIFF
--- a/skills/pick/SKILL.md
+++ b/skills/pick/SKILL.md
@@ -15,7 +15,7 @@ You are selecting the next work item from a GitHub repository. PRs with review f
 
 1. Run `ensure_labels` (no arguments needed — reads repo from environment).
 2. Run `get_prs_with_feedback` (no arguments needed).
-3. If there are PRs needing attention (changes requested or failing CI checks):
+3. If there are PRs needing attention (changes requested, failing CI checks, or merge conflicts):
    a. Pick the PR with the oldest `updatedAt` (longest waiting for attention).
    b. Write your output with `type` set to `"pr"` and the PR details. Include the `reason` field from the tool result.
    c. Skip the remaining steps.
@@ -44,7 +44,7 @@ For a PR with feedback:
   "body": "...",
   "url": "https://github.com/owner/repo/pull/123",
   "branch": "<headRefName from PR>",
-  "reason": "<changes_requested|checks_failing|changes_requested,checks_failing>",
+  "reason": "<changes_requested|checks_failing|merge_conflict|changes_requested,checks_failing|...>",
   "reviews": [...],
   "comments": [...]
 }

--- a/skills/pick/tools/get-prs-with-feedback.tl
+++ b/skills/pick/tools/get-prs-with-feedback.tl
@@ -1,13 +1,15 @@
 -- skills/pick/tools/get-prs-with-feedback.tl: list open PRs needing attention
 --
--- returns PRs that are blocked and need work: either reviewDecision is
--- CHANGES_REQUESTED, or CI checks are failing. for PRs labeled needs-review
--- (already addressed, waiting for reviewer): skips if only checks are failing,
--- and skips if the latest CHANGES_REQUESTED review predates the last commit
--- (we already pushed a fix). includes the PR if the review postdates the last
--- commit (new feedback from reviewer). each returned PR includes a "reason"
--- field: "changes_requested", "checks_failing", or
--- "changes_requested,checks_failing".
+-- returns PRs that are blocked and need work: reviewDecision is
+-- CHANGES_REQUESTED, CI checks are failing, or the PR has merge conflicts.
+-- for PRs labeled needs-review (already addressed, waiting for reviewer):
+-- skips if only checks are failing, and skips if the latest CHANGES_REQUESTED
+-- review predates the last commit (we already pushed a fix). includes the PR
+-- if the review postdates the last commit (new feedback from reviewer).
+-- merge conflicts always surface regardless of needs-review label — they
+-- require a rebase that hasn't happened yet.
+-- each returned PR includes a "reason" field: comma-separated combination of
+-- "changes_requested", "checks_failing", "merge_conflict".
 -- uses graphql with explicit owner/name to avoid gh CLI local repo context
 -- issues. reads WORK_REPO from environment to limit scope.
 -- module tool: returns a Tool record for ah to load via -t
@@ -35,6 +37,7 @@ query($owner: String!, $name: String!) {
         url
         headRefName
         reviewDecision
+        mergeable
         updatedAt
         body
         labels(first: 20) {
@@ -80,7 +83,7 @@ end
 
 return {
   name = "get_prs_with_feedback",
-  description = "List open pull requests that need attention: CHANGES_REQUESTED review status or failing CI checks. For PRs labeled needs-review, compares the latest CHANGES_REQUESTED review timestamp against the last commit — only includes the PR if the review is newer (new feedback from reviewer). Operates on the repo set by WORK_REPO environment variable.",
+  description = "List open pull requests that need attention: CHANGES_REQUESTED review status, failing CI checks, or merge conflicts. For PRs labeled needs-review, compares the latest CHANGES_REQUESTED review timestamp against the last commit — only includes the PR if the review is newer (new feedback from reviewer). Merge conflicts always surface regardless of needs-review label. Operates on the repo set by WORK_REPO environment variable.",
   input_schema = {
     type = "object",
     properties = {},
@@ -150,6 +153,9 @@ return {
         has_changes_requested = true
       end
 
+      -- check merge conflict status
+      local has_merge_conflict = pr.mergeable == "CONFLICTING"
+
       -- check CI status from last commit; also capture committedDate
       local has_checks_failing = false
       local last_commit_date: string = ""
@@ -193,8 +199,10 @@ return {
       -- the latest CHANGES_REQUESTED review against the last commit.
       -- if the review predates the commit, we already addressed it — skip.
       -- if the review postdates the commit, it's new feedback — include.
+      -- merge conflicts are never dominated by needs-review — they require
+      -- a rebase regardless of review state.
       local dominated_by_needs_review = false
-      if has_needs_review then
+      if has_needs_review and not has_merge_conflict then
         if not has_changes_requested then
           -- only signal is checks_failing; skip (transient after our push)
           dominated_by_needs_review = true
@@ -233,7 +241,7 @@ return {
         end
       end
 
-      if (has_changes_requested or has_checks_failing)
+      if (has_changes_requested or has_checks_failing or has_merge_conflict)
       and not dominated_by_needs_review
       and not dominated_by_empty_reviews then
         -- build reason string
@@ -243,6 +251,9 @@ return {
         end
         if has_checks_failing then
           reasons[#reasons + 1] = "checks_failing"
+        end
+        if has_merge_conflict then
+          reasons[#reasons + 1] = "merge_conflict"
         end
         local reason = table.concat(reasons, ",")
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -24,7 +24,8 @@ conventions, and build instructions for the target repository. Follow its guidan
 1. Check the `reason` field to understand why this PR needs attention:
    - `changes_requested`: reviewers requested changes. Read the `reviews` and `comments` fields.
    - `checks_failing`: CI checks are failing. Run the repo's CI/test commands to reproduce failures.
-   - `changes_requested,checks_failing`: both. Address review feedback and fix CI failures.
+   - `merge_conflict`: the PR branch has merge conflicts with the base branch. The clone phase rebases automatically — verify the rebase succeeded and re-run CI.
+   - Reasons can be comma-separated (e.g. `changes_requested,merge_conflict`). Address all.
 2. Read relevant files referenced in the feedback or failing tests.
 3. Identify what changes are needed.
 4. Write a plan that addresses each piece of feedback and/or fixes each CI failure.

--- a/work.mk
+++ b/work.mk
@@ -83,6 +83,12 @@ $(repo_ready): $(issue)
 		echo "==> checkout existing PR branch $(branch)"; \
 		git -C $(repo_dir) checkout $(branch); \
 		git -C $(repo_dir) pull origin $(branch); \
+		echo "==> rebase on $(default_branch)"; \
+		git -C $(repo_dir) rebase $(default_branch) || { \
+			echo "==> rebase conflict, aborting and resetting to $(default_branch)"; \
+			git -C $(repo_dir) rebase --abort; \
+			git -C $(repo_dir) reset --hard $(default_branch); \
+		}; \
 	else \
 		echo "==> checkout new branch $(branch)"; \
 		git -C $(repo_dir) checkout -B $(branch) $(default_branch); \


### PR DESCRIPTION
Fixes the issue where PRs with merge conflicts (like whilp/ah#383) were invisible to the work loop.

## Problem

`get_prs_with_feedback` only checked two signals: `CHANGES_REQUESTED` reviews and failing CI checks. It did not query the `mergeable` field from GitHub's GraphQL API. PRs with merge conflicts but no other actionable signals — especially those labeled `needs-review` — were silently skipped every hour.

Additionally, the clone phase never rebased PR branches onto the default branch, so even if a conflicting PR were picked, the do phase would work on a stale branch.

## Changes

- **`get-prs-with-feedback.tl`**: add `mergeable` to the GraphQL query. treat `CONFLICTING` as a new signal (`merge_conflict` reason). merge conflicts bypass the `needs-review` domination logic — they require a rebase regardless of review state.
- **`work.mk`**: clone phase now rebases PR branches on the default branch after checkout. if the rebase fails (unresolvable conflicts), falls back to `reset --hard` on the default branch so the do phase can re-apply changes cleanly.
- **`pick/SKILL.md`** and **`plan/SKILL.md`**: document `merge_conflict` as a valid reason value.