### PR TITLE
pick: check inline comments when detecting empty reviews

### DIFF
--- a/skills/pick/tools/get-prs-with-feedback.tl
+++ b/skills/pick/tools/get-prs-with-feedback.tl
@@ -58,6 +58,7 @@ query($owner: String!, $name: String!) {
             body
             state
             submittedAt
+            comments { totalCount }
           }
         }
         comments(last: 20) {
@@ -221,8 +222,14 @@ return {
             if submitted > last_commit_date then
               new_cr_count = new_cr_count + 1
               local body = (r.body as string) or ""
-              -- treat whitespace-only bodies as empty
-              if body:match("^%s*$") then
+              -- treat whitespace-only bodies as empty, but only if
+              -- the review also has no inline comments
+              local comment_count: integer = 0
+              local comments_obj = r.comments as {string: any}
+              if comments_obj then
+                comment_count = math.floor((comments_obj.totalCount as number) or 0) as integer
+              end
+              if body:match("^%s*$") and comment_count == 0 then
                 empty_cr_count = empty_cr_count + 1
               end
             end


### PR DESCRIPTION
Reviews with empty body but inline comments (e.g. code suggestions on specific lines) were incorrectly classified as empty by the `dominated_by_empty_reviews` check in `get-prs-with-feedback`. This caused PRs like https://github.com/whilp/cosmic/pull/292 to be permanently skipped by the work loop despite having substantive review feedback.

**Root cause:** PR #292 had a second CHANGES_REQUESTED review with an empty top-level body but 3 inline comments ("loop over longopts", "loop over shortopts", "define env vars as a table and loop over it"). The empty-review detection only checked `r.body`, missing the inline comments entirely.

**Fix:**
- Added `comments { totalCount }` to the GraphQL query for review nodes
- Changed the empty-review check: a review is only "empty" if it has both a whitespace-only body AND zero inline comments