### PR TITLE
work: fix skip exit not stopping subsequent recipe lines

### DIFF
--- a/work.mk
+++ b/work.mk
@@ -212,11 +212,11 @@ work: $(issue)
 	elif [ -n "$$error" ]; then \
 		echo "==> error: $$error"; \
 		exit 1; \
-	fi
-	@$(MAKE) "REPO=$(REPO)" $(plan)
-	-@LOOP=1 $(converge)
-	-@LOOP=2 $(converge)
-	@LOOP=3 $(converge)
+	fi; \
+	$(MAKE) "REPO=$(REPO)" $(plan) || exit $$?; \
+	LOOP=1 $(converge) || true; \
+	LOOP=2 $(converge) || true; \
+	LOOP=3 $(converge)
 
 # --- triage ---
 # standalone target: review open issues, close stale ones, split oversized ones.


### PR DESCRIPTION
## Problem

The `work` target in `work.mk` had multiple recipe lines (each a separate shell invocation). When pick returned `pr_limit` or `no_issues`, the `exit 0` on line 211 only terminated the first shell command (lines 208-215). Make then proceeded to line 216 (`$(MAKE) ... $(plan)`), which triggered `$(repo_ready)`, which called `test -n "$(branch)"` — and since the error issue.json had no branch field, this failed with:

```
==> skip: pr_limit
error: no branch in o/pick/issue.json
make[1]: *** [work.mk:75: o/repo/sha] Error 1
make: *** [work.mk:209: work] Error 2
```

This caused **9 consecutive workflow failures** between 19:14 and 03:45 UTC on 2026-02-19/20. Every repo in the matrix (ah, cosmic, working) hit either `pr_limit` (ah had 5 open PRs) or `no_issues` (cosmic/working had no todo items), and all reported as failures despite the skip being the correct behavior.

## Fix

Combine all recipe lines into a single shell command using backslash continuations. Now `exit 0` actually stops execution. Original semantics preserved:

- plan failure → fatal (`|| exit $$?`)
- converge loops 1-2 → tolerate failure (`|| true`)
- converge loop 3 → fatal (bare command)