### PR TITLE
check: scope PR items against session commits only

### DIFF
--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -24,16 +24,24 @@ Read `o/plan/plan.md` for the plan. Read `o/do/do.md` for the execution summary.
 ## Instructions
 
 1. Review the diff:
-   ```bash
-   git -C o/repo diff origin/main...HEAD
-   ```
+   - For issues: `git -C o/repo diff origin/main...HEAD`
+   - For PRs: review the full branch diff (`git -C o/repo diff origin/main...HEAD`)
+     for context, but note that only new commits (since `o/repo/sha`) are in scope.
 2. Run validation steps from the plan.
 3. Enforce scope limits:
    a. Extract the planned file list from `o/plan/plan.md`'s `## Files` section.
-   b. List actual changed files:
-      ```bash
-      git -C o/repo diff --name-only origin/main...HEAD
-      ```
+   b. List actual changed files. The diff range depends on the item type:
+      - For issues: diff the full branch against the default branch.
+        ```bash
+        git -C o/repo diff --name-only origin/main...HEAD
+        ```
+      - For PRs: diff only the new commits made during this work session.
+        `o/repo/sha` contains the branch HEAD at clone time (before do ran).
+        ```bash
+        git -C o/repo diff --name-only $(cat o/repo/sha)..HEAD
+        ```
+        If no new commits exist (sha equals HEAD), there are no changed files
+        to scope-check.
    c. Identify out-of-scope files — files in the diff but NOT in the plan's file list.
    d. Test files that correspond to a planned source file are acceptable (e.g.
       `test_foo.tl` for a planned `foo.tl`).


### PR DESCRIPTION
Closes #102

For PR feedback items, the check phase was diffing the full branch (`origin/main...HEAD`) against the plan's file list. Since the plan only covers new work, pre-existing commits on the PR branch got flagged as scope violations (as happened in [PR #93](https://github.com/whilp/working/pull/93#issuecomment-3931604159)).

## Fix

The scope check now uses different diff ranges by item type:

- **Issues**: `git diff --name-only origin/main...HEAD` (unchanged)
- **PRs**: `git diff --name-only $(cat o/repo/sha)..HEAD` — only new commits since clone time

`o/repo/sha` is already written by the clone phase (line 96 of work.mk) and captures HEAD before the do phase runs, making it the natural base point.

## Changes

- `skills/check/SKILL.md` — updated steps 1 and 3b to differentiate issue vs PR scope checking