### PR TITLE
pick: document inline review comments in output schema

### DIFF
--- a/skills/pick/SKILL.md
+++ b/skills/pick/SKILL.md
@@ -45,10 +45,27 @@ For a PR with feedback:
   "url": "https://github.com/owner/repo/pull/123",
   "branch": "<headRefName from PR>",
   "reason": "<changes_requested|checks_failing|merge_conflict|changes_requested,checks_failing|...>",
-  "reviews": [...],
+  "reviews": [
+    {
+      "author": "username",
+      "body": "review body text",
+      "state": "CHANGES_REQUESTED",
+      "submittedAt": "2026-01-01T00:00:00Z",
+      "comments": [
+        {
+          "path": "file.tl",
+          "line": 42,
+          "body": "inline comment text",
+          "createdAt": "2026-01-01T00:00:00Z"
+        }
+      ]
+    }
+  ],
   "comments": [...]
 }
 ```
+
+Copy the `reviews` array exactly as returned by `get_prs_with_feedback`, including each review's nested `comments` array (inline review comments). These inline comments contain file-specific feedback that downstream phases need to address.
 
 For an issue:
 


### PR DESCRIPTION
## Problem

cosmic PR #292 has three inline review comments requesting loop refactors in `help_test.tl`:
- `loop over longopts` (line 21)
- `loop over shortopts` (line 41)
- `define env vars as a table and loop over it` (line 54)

The work loop picked up the PR, but the do phase never addressed these comments. The agent pushed cosmetic commits (blank line changes in docstrings) that didn't fix anything.

## Root cause

Two issues:

1. **pick SKILL.md output schema was ambiguous**: the schema showed `"reviews": [...]` without specifying the nested `comments` array structure. The pick agent serialized reviews without their inline comments, so the plan/do agents saw the second review as having empty body and no feedback.

2. **After pushing unrelated commits, the PR became invisible**: the new commits made `last_commit_date > latest_cr_date`, and the act phase added `needs-review`. The `dominated_by_needs_review` logic then filtered the PR out permanently — even though the actual feedback was never addressed.

## Fix

- Expanded the pick SKILL.md output schema to show the full review object structure including nested inline comments
- Added explicit instruction to copy reviews exactly as returned by `get_prs_with_feedback`
- Removed `needs-review` label from cosmic PR #292 so it gets picked up on the next run

## Related

- https://github.com/whilp/cosmic/pull/292
- https://github.com/whilp/working/pull/96/files#r2828601137