### PR TITLE
ci-log: use remote sha instead of post-rebase sha

### DIFF
--- a/work.mk
+++ b/work.mk
@@ -84,6 +84,7 @@ $(repo_ready): $(issue)
 		echo "==> checkout existing PR branch $(branch)"; \
 		git -C $(repo_dir) checkout $(branch); \
 		git -C $(repo_dir) pull origin $(branch); \
+		git -C $(repo_dir) rev-parse HEAD > $(repo_dir)/remote-sha; \
 		echo "==> rebase on $(default_branch)"; \
 		git -C $(repo_dir) rebase $(default_branch) || { \
 			echo "==> rebase conflict, aborting and resetting to $(default_branch)"; \
@@ -105,7 +106,7 @@ $(ci_log): $(repo_ready) $(issue) $(cosmic)
 	@mkdir -p $(plan_dir)
 	@if [ "$(item_type)" = "pr" ]; then \
 		echo "==> ci-log"; \
-		sha=$$(cat $(repo_ready)); \
+		sha=$$(cat $(repo_dir)/remote-sha); \
 		$(cosmic) skills/plan/tools/get-ci-log.tl "$$sha" $(ci_log); \
 	else \
 		touch $@; \


### PR DESCRIPTION
fixes the work workflow failure where the ci-log step queries github's check-runs API with a post-rebase sha that doesn't exist on github yet.

## problem

the clone step rebases the PR branch onto main, creating a new local commit sha. the ci-log step then uses this sha to query `/commits/{sha}/check-runs`, which returns HTTP 422 because the sha hasn't been pushed.

this caused the [last work run](https://github.com/whilp/working/actions/runs/22249667354) to fail:
```
error: gh check-runs failed (exit 1): {"message":"No commit found for SHA: 53e64ab...",...}
```

## fix

save the remote branch sha (`rev-parse HEAD`) after pull but before rebase into `remote-sha`. the ci-log step reads this file instead of the repo-ready sha file. this sha is guaranteed to exist on github and have associated check runs.