### PR TITLE
plan: move get-ci-log out of tools/ to prevent sandbox loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ ah: $(ah)
 cosmic: $(cosmic)
 
 # sources
-tl_all := $(wildcard skills/*/tools/*.tl)
-tl_tests := $(wildcard skills/*/tools/test_*.tl)
+tl_all := $(wildcard skills/*/tools/*.tl) $(wildcard skills/*/lib/*.tl)
+tl_tests := $(wildcard skills/*/tools/test_*.tl) $(wildcard skills/*/lib/test_*.tl)
 tl_srcs := $(filter-out $(tl_tests),$(tl_all))
 
 TL_PATH := /zip/.lua/?.tl;/zip/.lua/?/init.tl;/zip/.lua/types/?.d.tl;/zip/.lua/types/?/init.d.tl

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -120,6 +120,6 @@ gh exit 4 means resource not found or access denied. always check for it before 
 
 keep logic and conditionals out of makefiles. makefiles define targets, dependencies, and invocations. non-trivial logic (API calls, parsing, branching) belongs in teal scripts that the makefile invokes. this keeps behavior testable and readable.
 
-good: `$(cosmic) skills/plan/tools/get-ci-log.tl "$$sha" $(ci_log)`
+good: `$(cosmic) skills/plan/lib/get-ci-log.tl "$$sha" $(ci_log)`
 
 bad: inline shell with pipes, grep chains, and nested conditionals in a makefile recipe.

--- a/skills/plan/lib/get-ci-log.tl
+++ b/skills/plan/lib/get-ci-log.tl
@@ -1,4 +1,4 @@
--- skills/plan/tools/get-ci-log.tl: fetch CI failure logs for a commit
+-- skills/plan/lib/get-ci-log.tl: fetch CI failure logs for a commit
 --
 -- given a repo and commit sha, finds failing check runs and downloads
 -- their logs. used by the ci-log make target to pre-fetch logs before

--- a/skills/plan/lib/test_get_ci_log.tl
+++ b/skills/plan/lib/test_get_ci_log.tl
@@ -1,6 +1,6 @@
--- skills/plan/tools/test_get_ci_log.tl: tests for get-ci-log tool
+-- skills/plan/lib/test_get_ci_log.tl: tests for get-ci-log tool
 
-local tool = require("skills.plan.tools.get-ci-log")
+local tool = require("skills.plan.lib.get-ci-log")
 
 -- tool record structure
 assert(tool.name == "get_ci_log", "name must be get_ci_log")

--- a/work.mk
+++ b/work.mk
@@ -107,7 +107,7 @@ $(ci_log): $(repo_ready) $(issue) $(cosmic)
 	@if [ "$(item_type)" = "pr" ]; then \
 		echo "==> ci-log"; \
 		sha=$$(cat $(repo_dir)/remote-sha); \
-		$(cosmic) skills/plan/tools/get-ci-log.tl "$$sha" $(ci_log); \
+		$(cosmic) skills/plan/lib/get-ci-log.tl "$$sha" $(ci_log); \
 	else \
 		touch $@; \
 	fi


### PR DESCRIPTION
## problem

the plan phase runs `ah --sandbox --skill plan`. ah auto-discovers and runs test files from the skill's `tools/` directory. `get-ci-log.tl` lived in `skills/plan/tools/`, so ah loaded it and ran `test_get_ci_log.tl` inside the sandbox.

the test calls `tool.execute()` which invokes `gh api`. inside the sandbox, `gh` can't connect to its unix auth socket, crashing with `error connecting to unix`. this killed the plan phase before it even started.

this was the root cause of all 3 jobs failing in recent work workflow runs — the ci-log sha fix (PR #105) was working correctly, but the plan phase died immediately after.

## fix

move `get-ci-log.tl` and its test from `skills/plan/tools/` to `skills/plan/lib/`. ah only auto-loads from `tools/`, so `lib/` is invisible to it. the file is only used as a CLI utility by the make recipe.

update Makefile globs to include `skills/*/lib/*.tl` for CI type checks, format checks, and tests.