### PR TITLE
pick: increase timeout from 60s to 120s

### DIFF
--- a/work.mk
+++ b/work.mk
@@ -48,7 +48,7 @@ LOOP ?= 1
 $(issue): $(ah) $(cosmic)
 	@mkdir -p $(pick_dir)
 	@echo "==> pick"
-	@timeout 60 $(ah) -n \
+	@timeout 120 $(ah) -n \
 		-m sonnet \
 		--skill pick \
 		--must-produce $(issue) \


### PR DESCRIPTION
## Problem

The pick phase times out after 60s in the work workflow. Both `whilp/cosmic` and `whilp/working` jobs failed with exit code 2 (timeout) in run [22250753273](https://github.com/whilp/working/actions/runs/22250753273).

Timeline from logs:
- pick started at 04:59:40
- exit code 2 at 05:00:40 (exactly 60s)

The pick phase needs to load tools, call multiple gh API endpoints (list issues, get PRs with feedback, count open PRs, ensure labels), and then make a selection. 60s is insufficient.

## Fix

Increase the pick timeout from 60s to 120s in work.mk.

## Validation

`make ci` passes (14 type checks, 14 format checks, 13 tests).