### PR TITLE
bump: update ah to 2026-02-21-39166c0

### DIFF
--- a/deps/ah.mk
+++ b/deps/ah.mk
@@ -1,2 +1,2 @@
-ah_url := https://github.com/whilp/ah/releases/download/2026-02-19-92bd8f5/ah
-ah_sha := 55dda9eb9376f9fc05e484c68eb68ba4dd5f27ee54f6e88cb84169ef1ea5ff6b
+ah_url := https://github.com/whilp/ah/releases/download/2026-02-21-39166c0/ah
+ah_sha := 132b3e6854eec472112163890984d691f314d0fcf24f12981fbae247727b98b4


### PR DESCRIPTION
update ah dependency from `2026-02-19-92bd8f5` to `2026-02-21-39166c0`.

new commits in this release:
- `39166c0` proxy: handle short writes and read before error break (#406)
- `1a65761` Makefile: use cosmic --test and cosmic --report (#402)