### PR TITLE
work: add build phase to pre-fetch deps and enable make ci in sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ when the app's permissions are changed in GitHub App settings, the installation 
 
 ```
 Makefile              build, test, ci targets; cosmic/ah dependency fetching
-work.mk               work loop targets (pick → clone → plan → do → push → check → act)
+work.mk               work loop targets (pick → clone → build → plan → do → push → check → act)
 reflect.mk            reflect loop targets (fetch → analyze → summarize → publish)
 lib/                  deterministic scripts (no agent invocation)
   build/              build-time utilities (lint)

--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -13,6 +13,7 @@ You are checking a work item. Review the execution against the plan.
 - The work item JSON follows this prompt after `---`.
 - If `type` is `"pr"`, you are checking that review feedback and/or CI failures were addressed (check the `reason` field).
 - If `type` is `"issue"`, you are checking new work against the plan.
+- Build dependencies are pre-fetched under `o/repo/o/`. You can run `make ci` (or individual targets like `make test`, `make check-types`, `make lint`) inside the sandbox.
 
 ## Setup
 
@@ -27,7 +28,8 @@ Read `o/plan/plan.md` for the plan. Read `o/do/do.md` for the execution summary.
    - For issues: `git -C o/repo diff origin/main...HEAD`
    - For PRs: review the full branch diff (`git -C o/repo diff origin/main...HEAD`)
      for context, but note that only new commits (since `o/repo/sha`) are in scope.
-2. Run validation steps from the plan.
+2. Run `cd o/repo && make ci` to validate the changes. If it fails, the verdict
+   MUST be `needs-fixes` (unless the failure is unrelated to the changes).
 3. Enforce scope limits:
    a. Extract the planned file list from `o/plan/plan.md`'s `## Files` section.
    b. List actual changed files. The diff range depends on the item type:

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -14,6 +14,7 @@ You are executing a work item. Follow the plan.
 - The work item JSON follows this prompt after `---`.
 - If `type` is `"pr"`, you are addressing review feedback on an existing PR.
 - If `type` is `"issue"`, you are implementing new work.
+- Build dependencies are pre-fetched under `o/repo/o/`. You can run `make ci` (or individual targets like `make test`, `make check-types`, `make lint`) inside the sandbox. Read `o/build/log.txt` for the initial CI output and `o/build/log.txt.exit` for the exit code.
 
 ## Setup
 
@@ -37,7 +38,7 @@ previous check. Address those issues first, then continue with any remaining pla
    d. Commit with a descriptive message for that step.
 5. Run format and lint checks from `o/repo/AGENTS.md` (e.g. `make check-format`,
    `make format`). Fix any issues and amend the last commit.
-6. Run validation steps from the plan (using `git -C o/repo` or `cd o/repo && ...`).
+6. Run `cd o/repo && make ci` to validate all changes. Fix any failures and amend.
 7. If validation requires fixes, stage and commit them.
 
 ## Forbidden

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -13,6 +13,7 @@ You are planning a work item. Research the codebase and write a plan.
 - The work item JSON follows this prompt after `---`. Fields: `type`, `number`, `title`, `body`, `url`, `branch`.
 - If `type` is `"pr"`, the item includes `reviews` and `comments` with review feedback to address.
 - If `type` is `"issue"`, the item is a new issue to implement.
+- `o/build/log.txt` contains the output of `make ci` run in the target repo after clone. `o/build/log.txt.exit` contains the exit code. Build dependencies (cosmic, etc.) are already fetched under `o/repo/o/`, so `make ci` works inside the sandbox.
 
 ## Instructions
 


### PR DESCRIPTION
## Problem

sandboxed phases (do, check) cant run `make ci` in target repos because the sandbox blocks network access. when `make ci` tries to fetch cosmic from github, it fails with `Error 7`. agents fall back to visual inspection and miss runtime failures — like the `"200k"` vs `"200.0k"` assertion mismatch in whilp/ah#403 that went undetected through multiple work runs.

## Fix

add a `build` phase between `clone` and `ci-log` that runs `make ci` in the target repo **outside** the sandbox. this:

1. fetches build dependencies (cosmic, etc.) and caches them under `o/repo/o/`
2. captures the full CI output to `o/build/log.txt` with exit code in `o/build/log.txt.exit`
3. makes both the cached deps and the log available to sandboxed phases via `--unveil o/build:r`

since dependencies are now pre-fetched, sandboxed `make ci` finds everything already built and runs without network access.

## Changes

- **work.mk**: new `build` target between clone and ci-log. runs `make ci`, captures output. wired as dependency for ci-log. plan/do/check get `--unveil o/build:r`.
- **skills/do/SKILL.md**: tell agent that `make ci` works in sandbox, point to build log.
- **skills/check/SKILL.md**: tell agent that `make ci` works in sandbox. step 2 now requires running `make ci` — verdict MUST be `needs-fixes` if it fails.
- **skills/plan/SKILL.md**: document build log location and that `make ci` works in sandbox.
- **docs/work.md**: add build phase description.
- **AGENTS.md**: update pipeline diagram.

## Pipeline

```
pick → clone → build → plan → do → push → check → act
```