### PR TITLE
work: add run-ah wrapper for timeout diagnostics

### DIFF
--- a/lib/work/run-ah.sh
+++ b/lib/work/run-ah.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# run-ah.sh: wrapper around ah that logs timing diagnostics.
+#
+# usage: run-ah.sh <timeout_seconds> <ah_binary> [ah_args...]
+#
+# logs timestamps to stderr so they appear in CI output even when
+# ah itself produces no output (e.g. API timeout).
+
+set -euo pipefail
+
+timeout_secs=$1; shift
+ah_bin=$1; shift
+
+ts() { date -u '+%Y-%m-%dT%H:%M:%SZ'; }
+
+echo "  [run-ah] $(ts) starting (timeout=${timeout_secs}s, model=${AH_MODEL:-unknown})" >&2
+
+start=$(date +%s)
+rc=0
+timeout "$timeout_secs" "$ah_bin" "$@" || rc=$?
+end=$(date +%s)
+elapsed=$((end - start))
+
+if [ "$rc" -eq 124 ]; then
+    echo "  [run-ah] $(ts) timed out after ${elapsed}s (limit=${timeout_secs}s)" >&2
+elif [ "$rc" -ne 0 ]; then
+    echo "  [run-ah] $(ts) exited ${rc} after ${elapsed}s" >&2
+else
+    echo "  [run-ah] $(ts) done in ${elapsed}s" >&2
+fi
+
+exit "$rc"

--- a/reflect.mk
+++ b/reflect.mk
@@ -42,7 +42,7 @@ $(fetch_done): $(ah) $(cosmic)
 	@echo "==> reflect: fetch runs $(SINCE)..$(UNTIL)"
 	# WORK_REPO is set inline, not globally — a global export would clobber
 	# work.mk's WORK_REPO := $(REPO) since reflect.mk is included second.
-	@WORK_REPO=$(REFLECT_REPO) timeout 300 $(ah) -n \
+	@WORK_REPO=$(REFLECT_REPO) $(run_ah) 300 $(ah) -n \
 		-m sonnet \
 		--skill reflect \
 		--must-produce $(fetch_done) \
@@ -75,7 +75,7 @@ analyze: $(analyze_done)
 $(reflection): $(analyze_done) $(ah)
 	@mkdir -p $(summarize_dir)
 	@echo "==> reflect: summarize"
-	@timeout 120 $(ah) -n \
+	@$(run_ah) 120 $(ah) -n \
 		-m sonnet \
 		--sandbox \
 		--skill reflect \

--- a/work.mk
+++ b/work.mk
@@ -22,6 +22,8 @@ REPO ?=
 export PATH := $(CURDIR)/$(o)/bin:$(PATH)
 export WORK_REPO := $(REPO)
 
+run_ah := lib/work/run-ah.sh
+
 # target repo clone
 repo_dir := $(o)/repo
 default_branch = $(or $(shell git -C $(repo_dir) symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/||'),origin/main)
@@ -54,7 +56,7 @@ LOOP ?= 1
 $(issue): $(ah) $(cosmic)
 	@mkdir -p $(pick_dir)
 	@echo "==> pick"
-	@timeout 120 $(ah) -n \
+	@$(run_ah) 120 $(ah) -n \
 		-m sonnet \
 		--skill pick \
 		--must-produce $(issue) \
@@ -145,7 +147,7 @@ plan: $(plan)
 $(plan): $(ci_log) $(repo_ready) $(issue) $(ah)
 	@echo "==> plan"
 	@mkdir -p $(plan_dir)
-	@timeout 180 $(ah) -n \
+	@$(run_ah) 180 $(ah) -n \
 		-m sonnet \
 		--sandbox \
 		--skill plan \
@@ -174,7 +176,7 @@ $(do_done): $(repo_ready) $(plan) $(feedback) $(issue) $(ah)
 		echo "  (retrying: resetting branch to $(default_branch))"; \
 		git -C $(repo_dir) reset --hard $(default_branch); \
 	fi
-	@timeout 300 $(ah) -n \
+	@$(run_ah) 300 $(ah) -n \
 		-m sonnet \
 		--sandbox \
 		--skill do \
@@ -207,7 +209,7 @@ check: $(check_done)
 $(check_done): $(push_done) $(plan) $(issue) $(ah)
 	@echo "==> check"
 	@mkdir -p $(check_dir)
-	@timeout 180 $(ah) -n \
+	@$(run_ah) 180 $(ah) -n \
 		-m sonnet \
 		--sandbox \
 		--skill check \
@@ -276,7 +278,7 @@ triage: $(triage_done)
 $(triage_done): $(triage_repo_ready) $(ah) $(cosmic)
 	@echo "==> triage"
 	@mkdir -p $(triage_dir)
-	@timeout 300 $(ah) -n \
+	@$(run_ah) 300 $(ah) -n \
 		-m sonnet \
 		--skill triage \
 		--must-produce $(triage_done) \
@@ -320,7 +322,7 @@ docs: $(docs_done)
 $(docs_done): $(docs_repo_ready) $(ah)
 	@echo "==> docs"
 	@mkdir -p $(docs_dir)
-	@timeout 300 $(ah) -n \
+	@$(run_ah) 300 $(ah) -n \
 		-m sonnet \
 		--sandbox \
 		--skill docs \
@@ -360,7 +362,7 @@ tests: $(tests_done)
 $(tests_done): $(tests_repo_ready) $(ah)
 	@echo "==> tests"
 	@mkdir -p $(tests_dir)
-	@timeout 300 $(ah) -n \
+	@$(run_ah) 300 $(ah) -n \
 		-m sonnet \
 		--sandbox \
 		--skill tests \
@@ -403,7 +405,7 @@ $(bump_done): $(bump_repo_ready) $(ah) $(cosmic)
 	@echo "==> bump"
 	@mkdir -p $(bump_dir)
 	@git -C $(repo_dir) checkout -B $(bump_branch)
-	@timeout 120 $(ah) -n \
+	@$(run_ah) 120 $(ah) -n \
 		-m sonnet \
 		--sandbox \
 		--skill bump \


### PR DESCRIPTION
## Problem

The `do` phase frequently times out with **zero output**, making it impossible to tell whether:
- `ah` failed to start
- the API connection hung
- the response stalled

Recent workflow runs show `ah` producing nothing for the full 300s timeout, then getting killed (exit 124). With no logging, we can't distinguish startup failures from API hangs.

## Changes

- **`lib/work/run-ah.sh`** — thin wrapper around `timeout` + `ah` that logs timestamped diagnostics to stderr:
  - `[run-ah] ... starting (timeout=300s, model=...)` before invoking ah
  - `[run-ah] ... timed out after 300s (limit=300s)` on timeout (exit 124)
  - `[run-ah] ... exited N after Ns` on other failures
  - `[run-ah] ... done in Ns` on success
- **`work.mk`** — replace all `timeout N $(ah)` with `$(run_ah) N $(ah)` (8 call sites)
- **`reflect.mk`** — same replacement (2 call sites)

## Example output

Normal run:
```
==> do
  [run-ah] 2026-02-22T20:02:16Z starting (timeout=300s, model=unknown)
  ... ah output ...
  [run-ah] 2026-02-22T20:05:13Z done in 177s
```

Timeout:
```
==> do
  [run-ah] 2026-02-22T20:02:16Z starting (timeout=300s, model=unknown)
  [run-ah] 2026-02-22T20:07:16Z timed out after 300s (limit=300s)
```

This confirms whether `ah` even starts and exactly how long it ran before the timeout killed it.