### PR TITLE
check: increase timeouts for slow CI repos

### DIFF
--- a/skills/check/SKILL.md
+++ b/skills/check/SKILL.md
@@ -28,8 +28,10 @@ Read `o/plan/plan.md` for the plan. Read `o/do/do.md` for the execution summary.
    - For issues: `git -C o/repo diff origin/main...HEAD`
    - For PRs: review the full branch diff (`git -C o/repo diff origin/main...HEAD`)
      for context, but note that only new commits (since `o/repo/sha`) are in scope.
-2. Run `cd o/repo && make ci` to validate the changes. If it fails, the verdict
-   MUST be `needs-fixes` (unless the failure is unrelated to the changes).
+2. Run `cd o/repo && make ci` to validate the changes. Use a 300s bash timeout
+   (`"timeout": 300000`) — some repos take over 2 minutes for a full CI run.
+   If it fails, the verdict MUST be `needs-fixes` (unless the failure is
+   unrelated to the changes).
 3. Enforce scope limits:
    a. Extract the planned file list from `o/plan/plan.md`'s `## Files` section.
    b. List actual changed files. The diff range depends on the item type:

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -38,7 +38,9 @@ previous check. Address those issues first, then continue with any remaining pla
    d. Commit with a descriptive message for that step.
 5. Run format and lint checks from `o/repo/AGENTS.md` (e.g. `make check-format`,
    `make format`). Fix any issues and amend the last commit.
-6. Run `cd o/repo && make ci` to validate all changes. Fix any failures and amend.
+6. Run `cd o/repo && make ci` to validate all changes. Use a 300s bash timeout
+   (`"timeout": 300000`) — some repos take over 2 minutes for a full CI run.
+   Fix any failures and amend.
 7. If validation requires fixes, stage and commit them.
 
 ## Forbidden

--- a/work.mk
+++ b/work.mk
@@ -209,7 +209,7 @@ check: $(check_done)
 $(check_done): $(push_done) $(plan) $(issue) $(ah)
 	@echo "==> check"
 	@mkdir -p $(check_dir)
-	@$(run_ah) 180 $(ah) -n \
+	@$(run_ah) 420 $(ah) -n \
 		-m sonnet \
 		--sandbox \
 		--skill check \


### PR DESCRIPTION
## Problem

cosmic's `make ci` takes ~227s on GH runners (137 source files × 5 sequential CI stages). the check phase had a 180s `ah` timeout and agents used the default 120s bash timeout, causing cascading timeouts:

1. agent runs `make ci` → bash tool timeout at 120s (default)
2. agent pivots to individual targets, but only ~60s left in session
3. 180s `ah` session timeout kills the process (exit 124)
4. convergence loop retries → same cascade repeats

observed in run [22284335430](https://github.com/whilp/working/actions/runs/22284335430) — the cosmic job was cancelled after two failed check attempts.

the do phase had the same `make ci` bash timeout issue but survived because it has a 300s `ah` timeout.

## Root cause

when the do phase modifies a core cosmic source file (e.g. `teal.tl`), `cosmic_bin` needs rebuilding, which invalidates ALL `.teal.got`, `.format.got`, and `.test.got` files. this makes `make ci` a full rebuild (~227s), exceeding the 120s bash default.

## Changes

- **work.mk**: increase check phase `ah` timeout from 180s to 420s
- **skills/check/SKILL.md**: add explicit guidance to use `"timeout": 300000` for `make ci`
- **skills/do/SKILL.md**: same guidance for the do phase