### PR TITLE
work: increase plan timeout from 180s to 300s

### DIFF
--- a/work.mk
+++ b/work.mk
@@ -147,7 +147,7 @@ plan: $(plan)
 $(plan): $(ci_log) $(repo_ready) $(issue) $(ah)
 	@echo "==> plan"
 	@mkdir -p $(plan_dir)
-	@$(run_ah) 180 $(ah) -n \
+	@$(run_ah) 300 $(ah) -n \
 		-m sonnet \
 		--sandbox \
 		--skill plan \


### PR DESCRIPTION
the plan phase timed out in the latest work run (run #22289835473, 2026-02-23T01:30:19Z). 180s is too tight — it's the second-lowest timeout after pick (120s), while plan often needs to read substantial codebases.

bumps plan timeout from 180s to 300s, matching the do phase timeout.