### PR TITLE
work: increase job timeout to 25m, reduce loops to 2

### DIFF
--- a/.github/workflows/work.yml
+++ b/.github/workflows/work.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   work:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     concurrency:
       group: work-${{ matrix.repo }}
       cancel-in-progress: false

--- a/work.mk
+++ b/work.mk
@@ -246,8 +246,7 @@ work: $(issue)
 	fi; \
 	$(MAKE) "REPO=$(REPO)" $(plan) || exit $$?; \
 	LOOP=1 $(converge) || true; \
-	LOOP=2 $(converge) || true; \
-	LOOP=3 $(converge)
+	LOOP=2 $(converge)
 
 # --- triage ---
 # standalone target: review open issues, close stale ones, split oversized ones.


### PR DESCRIPTION
the cosmic job was cancelled during the check phase because the 15-minute github job timeout was exceeded. the worst-case phase budget (pick 120s + build ~205s + plan 300s + do 300s×2 + check 420s) is ~27 minutes — well over 15m.

two changes:

1. **increase job timeout from 15m to 25m** — accommodates the full phase chain even with a do retry and cosmic's ~3.5m build.

2. **reduce convergence loops from 3 to 2** — the third loop rarely succeeds if the first two didn't. in the failing run, do timed out on loop 1 (300s) then succeeded on loop 2 (133s), but by then 14m had elapsed and check was cancelled. dropping the third loop saves up to 720s (do + check) of worst-case budget.