### PR TITLE
Refactor timestamp handling to use cosmic.time module

### DIFF
--- a/deps/cosmic.mk
+++ b/deps/cosmic.mk
@@ -1,2 +1,2 @@
-cosmic_url := https://github.com/whilp/cosmic/releases/download/2026-02-21-9cfae8d/cosmic-lua
-cosmic_sha := 61596fa28a6f43bd20fcb48b5fe741b9eb0dfdb146e287679d58b2befded4a11
+cosmic_url := https://github.com/whilp/cosmic/releases/download/2026-02-28-d518c77/cosmic-lua
+cosmic_sha := 40c7637ff7d2838c8e9ada431c1468221b08d5ed7aaaf3d816c1a0edf92b76e0

--- a/lib/work/unstick.tl
+++ b/lib/work/unstick.tl
@@ -12,6 +12,7 @@
 local child = require("cosmic.child")
 local cio = require("cosmic.io")
 local json = require("cosmic.json")
+local time = require("cosmic.time")
 
 local STALE_HOURS = 24
 
@@ -67,27 +68,7 @@ local function run(argv: {string}): boolean | string, string, number
   return ok, out, code
 end
 
--- parse ISO 8601 timestamp to unix epoch (UTC)
-local function parse_iso8601(s: string): number
-  local y, m, d, h, min, sec = s:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)")
-  if not y then return 0 end
-  -- os.time interprets as local time; we need UTC.
-  -- compute offset and adjust.
-  local utc_t: os.DateTable = {
-    year = tonumber(y) as integer,
-    month = tonumber(m) as integer,
-    day = tonumber(d) as integer,
-    hour = tonumber(h) as integer,
-    min = tonumber(min) as integer,
-    sec = tonumber(sec) as integer,
-  }
-  local t = os.time(utc_t)
-  -- find the offset between local and UTC
-  local local_dt = os.date("*t", t) as os.DateTable
-  local utc_dt = os.date("!*t", t) as os.DateTable
-  local offset = os.time(local_dt) - os.time(utc_dt)
-  return t - offset
-end
+local parse_iso8601 = time.parse_iso8601
 
 local function fetch_doing_issues(owner: string, name: string): {any}, string
   local all_issues: {any} = {}
@@ -254,12 +235,7 @@ local function execute(output_file: string): string
     return fetch_err
   end
 
-  local now = os.time(os.date("!*t") as os.DateTable)
-  -- adjust for UTC offset (same approach as parse_iso8601)
-  local sample_local = os.date("*t", now) as os.DateTable
-  local sample_utc = os.date("!*t", now) as os.DateTable
-  local offset = os.time(sample_local) - os.time(sample_utc)
-  now = now - offset
+  local now = time.now()
 
   local stale_seconds = STALE_HOURS * 3600
   local reset: {any} = {}


### PR DESCRIPTION
## Summary
Refactored timestamp parsing and current time retrieval to use utility functions from the `cosmic.time` module, eliminating duplicate UTC offset calculation logic.

## Key Changes
- Added `require("cosmic.time")` dependency to access time utility functions
- Replaced inline `parse_iso8601()` function with `time.parse_iso8601` reference
- Replaced inline UTC timestamp calculation in `execute()` with `time.now()` call
- Removed ~25 lines of duplicated UTC offset calculation logic that was previously implemented in two places

## Implementation Details
The changes consolidate UTC timestamp handling into the `cosmic.time` module, which provides:
- `parse_iso8601()`: Parses ISO 8601 timestamps to Unix epoch (UTC)
- `now()`: Returns current Unix timestamp adjusted for UTC offset

This eliminates code duplication and improves maintainability by centralizing timezone-aware time operations.

https://claude.ai/code/session_01WDcXzxMj1wga9JJqm2NkEM