### PR TITLE
act: fix tmpfile race in comment_issue and create_pr

### DIFF
--- a/lib/work/act.tl
+++ b/lib/work/act.tl
@@ -31,11 +31,12 @@ local function comment_issue(repo: string, issue_number: number, body: string): 
       "--repo", repo,
       "--body-file", tmp,
     }, {stderr = 1})
-  os.remove(tmp)
   if not h then
+    os.remove(tmp)
     return false, "gh failed: " .. (err or "spawn failed")
   end
   local ok, out, code = h:read()
+  os.remove(tmp)
   if not ok then
     return false, "gh failed (exit " .. tostring(code) .. "): " .. (out or "")
   end
@@ -52,11 +53,12 @@ local function create_pr(repo: string, branch: string, title: string, body: stri
       "--title", title,
       "--body-file", tmp,
     }, {stderr = 1})
-  os.remove(tmp)
   if not h then
+    os.remove(tmp)
     return false, "gh failed: " .. (err or "spawn failed")
   end
   local ok, out, code = h:read()
+  os.remove(tmp)
   if not ok then
     if out and out:find("already exists") then
       return true, nil


### PR DESCRIPTION
## Problem

Every act step in the work workflow fails with:
```
gh failed (exit 1): open /tmp/lua_XXXXXX: no such file or directory
```

This affects all three repos (ah, cosmic, working) on every run. The verdict is computed correctly and actions.json is written, but the actions themselves (commenting on issues, creating PRs, transitioning labels) all fail.

## Root Cause

In `lib/work/act.tl`, both `comment_issue()` and `create_pr()` write the body to a temp file, spawn `gh` with `--body-file`, then **immediately delete the temp file** before `gh` has a chance to read it:

```lua
child.spawn({"gh", ..., "--body-file", tmp})
os.remove(tmp)  -- gh hasn't opened the file yet
h:read()        -- gh fails trying to open deleted file
```

`child.spawn()` is async — it returns a handle immediately. The `gh` process hasn't started reading the file when `os.remove()` runs.

## Fix

Move `os.remove(tmp)` to after `h:read()`, so the temp file exists for the entire lifetime of the `gh` process. On spawn failure, remove immediately.

## Impact

This has been silently breaking **every** act step. Looking at the last 10 runs today:
- 9/10 runs marked "success" but all had `actions_failed > 0`
- No PRs were being created
- No issue comments were being posted
- Label transitions to "done" were not happening