### PR TITLE
pick: exclude done/doing/failed issues from list_issues

### DIFF
--- a/lib/work/unstick.tl
+++ b/lib/work/unstick.tl
@@ -303,14 +303,16 @@ local function execute(output_file: string): string
 
     local has_todo = false
     local has_doing = false
+    local has_done = false
     for _, lbl_any in ipairs(label_nodes) do
       local lbl = lbl_any as {string: any}
       local lname = lbl.name as string
       if lname == "todo" then has_todo = true end
       if lname == "doing" then has_doing = true end
+      if lname == "done" then has_done = true end
     end
 
-    if not has_todo and not has_doing then
+    if not has_todo and not has_doing and not has_done then
       local body = "Adding `todo`: issue had `failed` but no `todo` or `doing` label. "
       .. "This allows the work loop to pick it up again."
 

--- a/skills/pick/tools/list-issues.tl
+++ b/skills/pick/tools/list-issues.tl
@@ -1,6 +1,7 @@
 -- skills/pick/tools/list-issues.tl: fetch open issues from a github repo
 --
--- returns issues that are either labeled "todo" or filed by repo collaborators.
+-- returns issues that are either labeled "todo" or filed by repo collaborators,
+-- excluding any issue that has done, doing, or failed labels.
 -- reads WORK_REPO from environment to limit scope.
 -- module tool: returns a Tool record for ah to load via -t
 
@@ -37,7 +38,7 @@ local repo = os.getenv("WORK_REPO") or ""
 
 return {
   name = "list_issues",
-  description = "Fetch open issues from the target repository (set by WORK_REPO) that are either labeled 'todo' or filed by repo collaborators (owner/member/collaborator).",
+  description = "Fetch open issues from the target repository (set by WORK_REPO) that are either labeled 'todo' or filed by repo collaborators (owner/member/collaborator). Excludes issues with done, doing, or failed labels.",
   input_schema = {
     type = "object",
     properties = {},
@@ -100,8 +101,9 @@ return {
         local labels_conn = node.labels as {string: any}
         local label_nodes = labels_conn.nodes as {any}
 
-        -- check if issue has todo label
+        -- check labels: todo makes it eligible, done/doing/failed exclude it
         local has_todo = false
+        local has_terminal = false
         local label_list: {any} = {}
         for _, ln_any in ipairs(label_nodes) do
           local ln = ln_any as {string: any}
@@ -109,14 +111,19 @@ return {
           label_list[#label_list + 1] = {name = lname}
           if lname == "todo" then
             has_todo = true
+          elseif lname == "done" or lname == "doing" or lname == "failed" then
+            has_terminal = true
           end
         end
 
+        -- skip issues already in a work state (done, doing, failed)
         -- check if author is a collaborator
         local assoc = node.authorAssociation as string
         local is_collaborator = COLLABORATOR_ASSOCIATIONS[assoc] or false
 
-        if has_todo or is_collaborator then
+        if has_terminal then
+          -- do nothing: skip this issue
+        elseif has_todo or is_collaborator then
           local author_obj = node.author as {string: any}
           all_issues[#all_issues + 1] = {
             number = node.number,


### PR DESCRIPTION
## Problem

The work loop was creating duplicate PRs for the same issue. For example on whilp/ah:
- Issue #449 had **two** open PRs: #470 and #478
- Issue #447 had a PR (#475) created even though it was already labeled `done`
- Issues #350 and #344 had new PRs (#483, #479) despite being labeled `done`

## Root Cause

Two bugs in the pick/unstick pipeline:

### 1. `list_issues` did not filter state labels

`list_issues` returned all open issues filed by collaborators (OWNER/MEMBER/COLLABORATOR) regardless of their state labels. An issue labeled `done` (waiting for its PR to merge and auto-close the issue) was returned to the pick agent, which re-picked it and started a new work cycle — creating a duplicate branch and PR.

### 2. `unstick` rescued `done+failed` issues

`unstick.tl` adds `todo` to any issue with `failed` but no `todo`/`doing`. It did not check for `done`. So an issue with both `done` and `failed` (a previous attempt failed, a later attempt succeeded) got `todo` re-added, making it eligible for yet another pick.

## Fix

- **`list_issues.tl`**: skip any issue with `done`, `doing`, or `failed` labels. These issues are already in a work state and should not be re-picked.
- **`unstick.tl`**: skip failed issues that already have `done` — they completed successfully on a later attempt.

Also cleaned up issue #449 on whilp/ah (removed stale `todo` label).