### PR TITLE
unstick: mark repeatedly-stuck issues as failed

### DIFF
--- a/lib/work/test_unstick.tl
+++ b/lib/work/test_unstick.tl
@@ -13,7 +13,10 @@ local function test_exports()
   assert(type(unstick.parse_iso8601) == "function", "parse_iso8601 should be a function")
   assert(unstick.find_doing_labeled_at, "should export find_doing_labeled_at function")
   assert(type(unstick.find_doing_labeled_at) == "function", "find_doing_labeled_at should be a function")
+  assert(unstick.count_doing_labels, "should export count_doing_labels function")
+  assert(type(unstick.count_doing_labels) == "function", "count_doing_labels should be a function")
   assert(unstick.STALE_HOURS == 24, "STALE_HOURS should be 24")
+  assert(unstick.MAX_RESETS == 3, "MAX_RESETS should be 3")
   print("✓ unstick.tl exports expected functions and constants")
 end
 test_exports()
@@ -86,6 +89,49 @@ local function test_find_doing_labeled_at_empty()
   print("✓ find_doing_labeled_at returns empty for empty timeline")
 end
 test_find_doing_labeled_at_empty()
+
+local function test_count_doing_labels()
+  local node = {
+    timelineItems = {
+      nodes = {
+        {createdAt = "2025-01-01T10:00:00Z", label = {name = "doing"}},
+        {createdAt = "2025-01-02T10:00:00Z", label = {name = "doing"}},
+        {createdAt = "2025-01-01T15:00:00Z", label = {name = "todo"}},
+        {createdAt = "2025-01-03T10:00:00Z", label = {name = "doing"}},
+      },
+    },
+  }
+  local count = unstick.count_doing_labels(node as {string: any})
+  assert(count == 3, "should count 3 doing labels, got " .. tostring(count))
+  print("✓ count_doing_labels counts doing labels correctly")
+end
+test_count_doing_labels()
+
+local function test_count_doing_labels_none()
+  local node = {
+    timelineItems = {
+      nodes = {
+        {createdAt = "2025-01-01T10:00:00Z", label = {name = "todo"}},
+      },
+    },
+  }
+  local count = unstick.count_doing_labels(node as {string: any})
+  assert(count == 0, "should count 0 doing labels, got " .. tostring(count))
+  print("✓ count_doing_labels returns 0 when no doing labels")
+end
+test_count_doing_labels_none()
+
+local function test_count_doing_labels_empty()
+  local node = {
+    timelineItems = {
+      nodes = {},
+    },
+  }
+  local count = unstick.count_doing_labels(node as {string: any})
+  assert(count == 0, "should count 0 for empty timeline, got " .. tostring(count))
+  print("✓ count_doing_labels returns 0 for empty timeline")
+end
+test_count_doing_labels_empty()
 
 local function test_cli_missing_args()
   local ok = os.execute("cosmic lib/work/unstick.tl 2>/dev/null")

--- a/lib/work/unstick.tl
+++ b/lib/work/unstick.tl
@@ -3,8 +3,12 @@
 -- deterministic script that:
 -- 1. queries issues labeled "doing", checks when the label was
 --    applied, and resets stale ones (>24h) back to "todo".
+--    if an issue has been reset too many times (doing label applied
+--    MAX_RESETS+1 or more times), it is marked "failed" instead to
+--    break infinite pick-fail-unstick loops.
 -- 2. queries issues labeled "failed" that lack both "todo" and
 --    "doing", and adds "todo" so the work loop can pick them up.
+--    issues just marked "failed" by step 1 are excluded.
 --
 -- CLI: cosmic unstick.tl <output_file>
 -- reads WORK_REPO from environment.
@@ -15,6 +19,7 @@ local json = require("cosmic.json")
 local time = require("cosmic.time")
 
 local STALE_HOURS = 24
+local MAX_RESETS = 3
 
 -- query issues labeled "doing" with their label timeline events
 local DOING_QUERY = [[
@@ -187,6 +192,20 @@ local function find_doing_labeled_at(node: {string: any}): string
   return latest
 end
 
+local function count_doing_labels(node: {string: any}): number
+  local timeline = node.timelineItems as {string: any}
+  local tl_nodes = timeline.nodes as {any}
+  local count = 0
+  for _, ev_any in ipairs(tl_nodes) do
+    local ev = ev_any as {string: any}
+    local label = ev.label as {string: any}
+    if label and (label.name as string) == "doing" then
+      count = count + 1
+    end
+  end
+  return count
+end
+
 local function comment_issue(repo: string, issue_number: number, body: string): boolean, string
   local tmp = os.tmpname()
   cio.barf(tmp, body)
@@ -239,6 +258,8 @@ local function execute(output_file: string): string
 
   local stale_seconds = STALE_HOURS * 3600
   local reset: {any} = {}
+  local failed: {any} = {}
+  local just_failed: {number: boolean} = {}
 
   for _, node_any in ipairs(issues) do
     local node = node_any as {string: any}
@@ -261,31 +282,67 @@ local function execute(output_file: string): string
 
     if age_seconds > stale_seconds then
       local hours = math.floor(age_seconds / 3600)
-      local body = "Resetting from `doing` to `todo`: issue has been in `doing` state for "
-      .. tostring(hours) .. "h (threshold: " .. tostring(STALE_HOURS) .. "h). "
-      .. "This allows the work loop to pick it up again."
+      local doing_count = count_doing_labels(node)
+      -- doing_count tracks how many times the "doing" label was applied.
+      -- each pick-fail-unstick cycle adds one. if the count exceeds
+      -- MAX_RESETS, the issue is stuck in a loop and should be failed.
+      local past_resets = doing_count - 1 -- current "doing" doesn't count as a reset
+      if past_resets < 0 then past_resets = 0 end
 
-      local ok, err = comment_issue(repo, num, body)
-      if not ok then
-        io.stderr:write("comment #" .. tostring(num) .. " failed: " .. (err or "") .. "\n")
+      if past_resets >= MAX_RESETS then
+        -- too many resets: mark as failed to break the loop
+        local body = "Marking as `failed`: issue has been reset from `doing` "
+        .. tostring(past_resets) .. " time(s) (limit: " .. tostring(MAX_RESETS) .. "). "
+        .. "The work loop cannot complete this issue. "
+        .. "Remove `failed` and add `todo` to retry manually."
+
+        local ok, err = comment_issue(repo, num, body)
+        if not ok then
+          io.stderr:write("comment #" .. tostring(num) .. " failed: " .. (err or "") .. "\n")
+        end
+
+        ok, err = set_labels(repo, num, {"failed"}, {"doing"})
+        if not ok then
+          io.stderr:write("labels #" .. tostring(num) .. " failed: " .. (err or "") .. "\n")
+        end
+
+        just_failed[num] = true
+        failed[#failed + 1] = {
+          number = num,
+          title = title,
+          labeled_at = labeled_at,
+          age_hours = hours,
+          doing_count = doing_count,
+        }
+      else
+        local body = "Resetting from `doing` to `todo`: issue has been in `doing` state for "
+        .. tostring(hours) .. "h (threshold: " .. tostring(STALE_HOURS) .. "h). "
+        .. "This allows the work loop to pick it up again."
+
+        local ok, err = comment_issue(repo, num, body)
+        if not ok then
+          io.stderr:write("comment #" .. tostring(num) .. " failed: " .. (err or "") .. "\n")
+        end
+
+        ok, err = set_labels(repo, num, {"todo"}, {"doing"})
+        if not ok then
+          io.stderr:write("labels #" .. tostring(num) .. " failed: " .. (err or "") .. "\n")
+        end
+
+        reset[#reset + 1] = {
+          number = num,
+          title = title,
+          labeled_at = labeled_at,
+          age_hours = hours,
+          doing_count = doing_count,
+        }
       end
-
-      ok, err = set_labels(repo, num, {"todo"}, {"doing"})
-      if not ok then
-        io.stderr:write("labels #" .. tostring(num) .. " failed: " .. (err or "") .. "\n")
-      end
-
-      reset[#reset + 1] = {
-        number = num,
-        title = title,
-        labeled_at = labeled_at,
-        age_hours = hours,
-      }
     end
   end
 
   -- rescue failed-only issues: add "todo" to issues that have "failed"
-  -- but lack both "todo" and "doing"
+  -- but lack both "todo" and "doing".
+  -- skip issues just marked "failed" above to avoid undoing the escalation.
   local failed_issues, failed_err = fetch_failed_issues(owner, name)
   if failed_err then
     io.stderr:write(failed_err .. "\n")
@@ -298,6 +355,12 @@ local function execute(output_file: string): string
     local node = node_any as {string: any}
     local num = math.floor(node.number as number)
     local title = node.title as string
+
+    -- skip issues we just escalated to "failed" in this run
+    if just_failed[num] then
+      goto continue
+    end
+
     local labels_conn = node.labels as {string: any}
     local label_nodes = labels_conn.nodes as {any}
 
@@ -331,6 +394,8 @@ local function execute(output_file: string): string
         title = title,
       }
     end
+
+    ::continue::
   end
 
   local result = json.encode({
@@ -338,12 +403,15 @@ local function execute(output_file: string): string
       doing_count = #issues,
       reset_count = #reset,
       reset = reset,
+      failed_count = #failed,
+      failed = failed,
       rescued_count = #rescued,
       rescued = rescued,
     })
 
   cio.barf(output_file, result)
   return "ok: reset " .. tostring(#reset) .. " of " .. tostring(#issues) .. " doing issues"
+  .. ", failed " .. tostring(#failed)
   .. ", rescued " .. tostring(#rescued) .. " failed-only issues"
 end
 
@@ -366,5 +434,7 @@ return {
   execute = execute,
   parse_iso8601 = parse_iso8601,
   find_doing_labeled_at = find_doing_labeled_at,
+  count_doing_labels = count_doing_labels,
   STALE_HOURS = STALE_HOURS,
+  MAX_RESETS = MAX_RESETS,
 }


### PR DESCRIPTION
## Problem

The work loop and unstick workflow are stuck in an infinite cycle:

1. **Unstick** resets stale `doing` issues back to `todo` (daily at 05:00 UTC)
2. **Work loop** picks the issue, labels it `doing` (hourly)
3. Work loop **fails** (e.g., plan timeout on complex issues like ah#343, ah#228)
4. Issue is left stuck in `doing` — no cleanup on failure
5. Next day, unstick resets it again → goto 2

This has been happening for days. Currently 6 issues in `whilp/ah` and 2 in `whilp/cosmic` are stuck in `doing` with no progress. The work loop has been returning `no_issues` for every run because all eligible issues are trapped in `doing`.

### Evidence

- `whilp/ah#228`: `doing` applied 5+ times, reset by unstick, re-picked and failed again
- `whilp/ah#442`: `doing` applied 3 times across Mar 2-3, reset twice, re-picked and failed
- `whilp/ah#450`: same pattern — reset Mar 4 05:22, re-picked Mar 4 06:09, stuck again
- Last 15+ work runs all returned `{"error": "no_issues"}` across all 3 repos

## Fix

Count how many times the `doing` label has been applied to an issue (from the timeline `LABELED_EVENT` data already fetched). If the count indicates the issue has been reset ≥ `MAX_RESETS` (3) times, label it `failed` instead of `todo`. This breaks the loop.

### Changes

- **`lib/work/unstick.tl`**:
  - Add `count_doing_labels()` helper — counts `doing` label events in the timeline
  - Add `MAX_RESETS = 3` constant
  - Before resetting doing→todo, check if `doing_count - 1 >= MAX_RESETS`
  - If over limit: label `failed` (not `todo`), leave explanatory comment
  - Track `just_failed` issue numbers to exclude them from the rescue pass (which would otherwise immediately re-add `todo` to `failed`-only issues)
  - Add `failed_count` and `failed` array to output JSON

- **`lib/work/test_unstick.tl`**:
  - Test `count_doing_labels` with multiple doing labels, no doing labels, empty timeline
  - Test `MAX_RESETS` constant export

### How it works after this change

| doing count | past resets | action |
|---|---|---|
| 1 | 0 | reset to `todo` (first time stuck) |
| 2 | 1 | reset to `todo` (second time) |
| 3 | 2 | reset to `todo` (third time) |
| 4+ | 3+ | mark `failed` — needs human intervention |

To retry a failed issue: remove `failed`, add `todo`.