### PR TITLE
do: extract timeout notes and increase timeout to 420s

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ work.mk               work loop targets (pick → clone → build → plan → d
 reflect.mk            reflect loop targets (fetch → analyze → summarize → publish)
 lib/                  deterministic scripts (no agent invocation)
   build/              build-time utilities (lint)
-  work/               work loop scripts (act, unstick)
+  work/               work loop scripts (act, unstick, extract-do-notes)
 tools/                shared tool modules (comment-issue, create-pr, set-issue-labels)
 test/                 tests for shared modules
   tools/              tests for shared tool modules

--- a/docs/work.md
+++ b/docs/work.md
@@ -24,7 +24,7 @@ each phase is a make target with file-based dependencies. outputs go to `o/`.
 
 **plan** — reads the repo and work item, writes a step-by-step plan to `o/plan/plan.md`. for PRs, the plan addresses each piece of review feedback. for issues, the plan covers the implementation. research only, no source changes.
 
-**do** — executes the plan in `o/repo/`. makes changes, runs validation, commits. writes `o/do/do.md`.
+**do** — executes the plan in `o/repo/`. makes changes, runs validation, commits. writes `o/do/do.md`. on timeout, extracts learnings from the session database (errors encountered, key observations, uncommitted changes) into `o/do/feedback.md` so the next attempt can continue efficiently.
 
 **push** — pushes the feature branch to origin.
 
@@ -35,6 +35,8 @@ each phase is a make target with file-based dependencies. outputs go to `o/`.
 ## convergence
 
 when check writes `needs-fixes`, it also writes `o/do/feedback.md`. since do depends on feedback.md, the next make run re-executes do → push → check. `make work` retries up to 3 times.
+
+when do times out, `lib/work/extract-do-notes.lua` extracts learnings from the session database (assistant observations, tool errors, uncommitted diffs) into `o/do/feedback.md`. the LOOP=2 retry reads these notes and can build on the previous attempt's progress instead of starting from scratch.
 
 ## agent invocation
 

--- a/lib/work/extract-do-notes.tl
+++ b/lib/work/extract-do-notes.tl
@@ -1,0 +1,149 @@
+-- extract-do-notes.tl: extract learnings from a timed-out do session.
+--
+-- reads the session database and git diff to produce a notes file
+-- that the next do attempt can use to avoid repeating mistakes.
+--
+-- usage: cosmic extract-do-notes.tl <session_db> <repo_dir> <output_file>
+
+local sql = require("cosmo.lsqlite3")
+local cio = require("cosmic.io")
+
+local args = arg as {string}
+if #args < 3 then
+  io.stderr:write("usage: extract-do-notes.tl <session_db> <repo_dir> <output_file>\n")
+  os.exit(1)
+end
+
+local db_path = args[1]
+local repo_dir = args[2]
+local output_path = args[3]
+
+-- open session database
+local db = sql.open(db_path)
+if not db then
+  io.stderr:write("error: cannot open " .. db_path .. "\n")
+  os.exit(1)
+end
+
+-- collect assistant text blocks (learnings, observations)
+local texts: {string} = {}
+db:exec([[
+   SELECT cb.content
+   FROM content_blocks cb
+   JOIN messages m ON cb.message_id = m.id
+   WHERE m.role = 'assistant'
+     AND cb.block_type = 'text'
+     AND cb.content IS NOT NULL
+     AND cb.content != ''
+   ORDER BY m.created_at ASC, cb.seq ASC
+]], function(_: any, _ncols: integer, values: {string}, _names: {string}): integer
+    table.insert(texts, values[1])
+    return 0
+  end)
+
+-- collect tool errors (is_error = 1)
+local errors: {string} = {}
+db:exec([[
+   SELECT cb.tool_name, cb.content
+   FROM content_blocks cb
+   JOIN messages m ON cb.message_id = m.id
+   WHERE cb.block_type = 'tool_result'
+     AND cb.is_error = 1
+     AND cb.content IS NOT NULL
+     AND cb.content != ''
+   ORDER BY m.created_at ASC, cb.seq ASC
+]], function(_: any, _ncols: integer, values: {string}, _names: {string}): integer
+    local tool = values[1] or "unknown"
+    local content = values[2]
+    if #content > 500 then
+      content = content:sub(1, 500) .. "\n... (truncated)"
+    end
+    table.insert(errors, "- `" .. tool .. "`: " .. content)
+    return 0
+  end)
+
+db:close()
+
+-- get git diff (uncommitted changes)
+local diff = ""
+local handle = io.popen("git -C " .. repo_dir .. " diff HEAD 2>/dev/null")
+if handle then
+  diff = handle:read("*a") or ""
+  handle:close()
+end
+
+-- get git status
+local status = ""
+local status_handle = io.popen(
+  "git -C " .. repo_dir .. " status --short 2>/dev/null"
+)
+if status_handle then
+  status = status_handle:read("*a") or ""
+  status_handle:close()
+end
+
+-- build the notes file
+local parts: {string} = {}
+table.insert(parts, "# Do Phase Timeout Notes")
+table.insert(parts, "")
+table.insert(parts, "The previous do attempt timed out. " ..
+  "Use these notes to continue efficiently.")
+table.insert(parts, "Do NOT repeat the same approach " ..
+  "if it led to errors below.")
+table.insert(parts, "")
+
+if #errors > 0 then
+  table.insert(parts, "## Errors Encountered")
+  table.insert(parts, "")
+  for _, e in ipairs(errors) do
+    table.insert(parts, e)
+  end
+  table.insert(parts, "")
+end
+
+-- include last few assistant observations (most valuable learnings)
+if #texts > 0 then
+  table.insert(parts, "## Key Observations from Previous Attempt")
+  table.insert(parts, "")
+  -- take last 5 text blocks — most recent learnings
+  local start_idx = math.max(1, #texts - 4)
+  for i = start_idx, #texts do
+    table.insert(parts, texts[i])
+    table.insert(parts, "")
+  end
+end
+
+if status ~= "" then
+  table.insert(parts, "## Uncommitted Changes")
+  table.insert(parts, "")
+  table.insert(parts, "The previous attempt left these " ..
+    "uncommitted changes in the working tree:")
+  table.insert(parts, "")
+  table.insert(parts, "```")
+  table.insert(parts, status)
+  table.insert(parts, "```")
+  table.insert(parts, "")
+  table.insert(parts, "Review these changes — they may be " ..
+    "correct and just need committing,")
+  table.insert(parts, "or they may need formatting/type " ..
+    "fixes before committing.")
+  table.insert(parts, "")
+end
+
+if diff ~= "" then
+  -- truncate very large diffs
+  if #diff > 5000 then
+    diff = diff:sub(1, 5000) ..
+    "\n... (truncated, run `git diff` to see full)"
+  end
+  table.insert(parts, "## Diff")
+  table.insert(parts, "")
+  table.insert(parts, "```diff")
+  table.insert(parts, diff)
+  table.insert(parts, "```")
+end
+
+local content = table.concat(parts, "\n")
+cio.barf(output_path, content)
+
+io.stderr:write("  extracted do notes to " .. output_path .. "\n")

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -23,8 +23,10 @@ conventions, and build instructions for the target repository. Follow its guidan
 
 Read `o/plan/plan.md` for the full plan.
 
-Read `o/do/feedback.md` — if non-empty, it contains review feedback from a
-previous check. Address those issues first, then continue with any remaining plan steps.
+Read `o/do/feedback.md` — if non-empty, it contains notes from a previous attempt.
+This may be review feedback from a check phase, or timeout notes from a timed-out
+do attempt (with errors encountered, key observations, and uncommitted changes).
+Address those issues first, then continue with any remaining plan steps.
 
 ## Instructions
 

--- a/work.mk
+++ b/work.mk
@@ -186,14 +186,14 @@ $(feedback): $(plan)
 .PHONY: do
 do: $(do_done)
 
-$(do_done): $(repo_ready) $(plan) $(feedback) $(issue) $(ah)
+$(do_done): $(repo_ready) $(plan) $(feedback) $(issue) $(ah) $(cosmic)
 	@echo "==> do"
 	@mkdir -p $(do_dir)
 	@if [ "$(item_type)" != "pr" ] && ! git -C $(repo_dir) diff --quiet $(default_branch)..HEAD 2>/dev/null; then \
 		echo "  (retrying: resetting branch to $(default_branch))"; \
 		git -C $(repo_dir) reset --hard $(default_branch); \
 	fi
-	@$(run_ah) 300 $(ah) -n \
+	@rc=0; $(run_ah) 420 $(ah) -n \
 		-m sonnet \
 		--sandbox \
 		--skill do \
@@ -205,7 +205,15 @@ $(do_done): $(repo_ready) $(plan) $(feedback) $(issue) $(ah)
 		--unveil $(plan_dir):r \
 		--unveil $(o)/build:r \
 		--unveil .:r \
-		< $(issue)
+		< $(issue) || rc=$$?; \
+	if [ "$$rc" -eq 124 ] && [ -f $(do_dir)/session-$(LOOP).db ]; then \
+		echo "  extracting timeout notes from session"; \
+		$(cosmic) lib/work/extract-do-notes.tl \
+			$(do_dir)/session-$(LOOP).db \
+			$(repo_dir) \
+			$(feedback); \
+	fi; \
+	[ "$$rc" -eq 0 ]
 	@touch $@
 
 # --- push ---


### PR DESCRIPTION
## summary

two changes to help the `do` phase handle large tasks:

### 1. extract timeout notes

when the `do` phase times out, `lib/work/extract-do-notes.tl` runs against the session database and writes learnings to `o/do/feedback.md`:

- **errors encountered** — tool errors from the session (type check failures, CI errors)
- **key observations** — last 5 assistant text blocks (what the agent figured out)
- **uncommitted changes** — git status and diff showing what edits were made

the LOOP=2 retry reads `feedback.md` and can build on the previous attempt's progress instead of starting from scratch.

### 2. increase do timeout to 420s

300s was too tight for tasks with many edit sites + a full CI run (~150s for ah). 420s gives 2 more minutes of breathing room.

## motivation

issue [whilp/ah#442](https://github.com/whilp/ah/issues/442) was picked 4 times and failed identically every time: the agent made all edits correctly but timed out during `make ci` validation. each LOOP=2 retry started with the previous attempt's uncommitted changes but had no context about what was already tried, leading to repeated work on formatting and type errors.

## files

- `lib/work/extract-do-notes.tl` — new script to extract learnings from session DB via `db:exec` callbacks
- `work.mk` — timeout 300→420, run extraction on timeout (exit 124), add `$(cosmic)` dependency
- `skills/do/SKILL.md` — update feedback.md description to mention timeout notes
- `docs/work.md` — document timeout notes in convergence section
- `AGENTS.md` — add extract-do-notes to structure listing