### PR TITLE
bump: update deps, add parallel builds and --include-dir

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run type checks and format checks
-        run: make -j ci
+        run: make ci

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ MAKEFLAGS += --no-print-directory
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-builtin-variables
 MAKEFLAGS += --output-sync
+MAKEFLAGS += -j$(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)
 export COSMIC_NO_WELCOME = 1
 
 o := o
@@ -61,15 +62,14 @@ tl_all := $(wildcard tools/*.tl) $(wildcard skills/*/tools/*.tl) $(wildcard skil
 tl_tests := $(wildcard test/tools/test_*.tl) $(wildcard skills/*/tests/test_*.tl) $(wildcard lib/*/test_*.tl)
 tl_srcs := $(filter-out $(tl_tests),$(tl_all))
 
-TL_PATH := /zip/.tl/?.tl;/zip/.tl/?/init.tl;/zip/.lua/types/?.d.tl;/zip/.lua/types/?/init.d.tl
-TL_PATH_TEST := ?.tl;?/init.tl;$(TL_PATH)
+TL_PATH_TEST := ?.tl;?/init.tl;/zip/.tl/?.tl;/zip/.tl/?/init.tl;/zip/.lua/types/?.d.tl;/zip/.lua/types/?/init.d.tl
 
 # type checking
 all_type_checks := $(patsubst %,$(o)/%.types,$(tl_srcs))
 
 $(o)/%.tl.types: %.tl $(cosmic)
 	@mkdir -p $(@D)
-	-@TL_PATH='$(TL_PATH)' $(cosmic) --test $@ $(cosmic) --check-types $<
+	-@$(cosmic) --test $@ $(cosmic) --check-types $<
 
 .PHONY: check-types
 check-types: $(all_type_checks)

--- a/deps/ah.mk
+++ b/deps/ah.mk
@@ -1,2 +1,2 @@
-ah_url := https://github.com/whilp/ah/releases/download/2026-03-01-a229baa/ah
-ah_sha := 67d9e7e249380fb3dd42a5f734f14c07d3f95f612ee60e2574e38229dde9653a
+ah_url := https://github.com/whilp/ah/releases/download/2026-03-08-be343f9/ah
+ah_sha := f32eb467f78ce31021f12a6787e0290525fd20ed97b2dc404f78bc78f54c459e

--- a/deps/cosmic.mk
+++ b/deps/cosmic.mk
@@ -1,2 +1,2 @@
-cosmic_url := https://github.com/whilp/cosmic/releases/download/2026-03-02-c363a79/cosmic-lua
-cosmic_sha := 9dc7fc906431ea5f40d18a0710010aa231a762edcd13e20c718cda91c6be91f9
+cosmic_url := https://github.com/whilp/cosmic/releases/download/2026-03-08-ac3a5d5/cosmic-lua
+cosmic_sha := 4aee99daab172af2c662354e519170fa5c5793e5820e8a2bcd02f23f1d99e531


### PR DESCRIPTION
update cosmic to `2026-03-08-ac3a5d5` and ah to `2026-03-08-be343f9`.

### changes

1. **deps/cosmic.mk**: bump to latest prerelease (adds `--include-dir` flag support)
2. **deps/ah.mk**: bump to latest prerelease (fast tool loading, parallel build support)
3. **Makefile**:
   - add `MAKEFLAGS += -j$(nproc)` for parallel builds
   - replace `TL_PATH` env var with cosmic built-in type resolution for `--check-types` (cosmic now finds its own `/zip/` types without TL_PATH)
   - keep `TL_PATH_TEST` for test execution (tests need `?.tl` path resolution)
4. **test.yml**: drop redundant `-j` flag from workflow (Makefile now handles parallelism)

### expected improvement

based on the same changes in whilp/ah (PR #502): **76s → 16s** (-79%) from parallel make + removing per-file TL_PATH overhead.