### PR TITLE
deps: fix ah release URL

### DIFF
--- a/deps/ah.mk
+++ b/deps/ah.mk
@@ -1,2 +1,2 @@
-ah_url := https://github.com/whilp/ah/releases/download/2026-03-08-be343f9/ah
-ah_sha := f32eb467f78ce31021f12a6787e0290525fd20ed97b2dc404f78bc78f54c459e
+ah_url := https://github.com/whilp/ah/releases/download/2026-03-07-896082d/ah
+ah_sha := dccde782dce84d9b0bf747d03fdbf388485fac7d71b752821ef1c4d6b43768fa


### PR DESCRIPTION
The pinned ah release 2026-03-08-be343f9 does not exist, causing a 404
during CI. Update to the latest available release 2026-03-07-896082d.

https://claude.ai/code/session_01DU1V23822fDhHJxBpHN56S